### PR TITLE
remove documentation links which point to developer-only wiki (bsc#10…

### DIFF
--- a/locale/metadata/README.md
+++ b/locale/metadata/README.md
@@ -1,7 +1,2 @@
 The metadata of Salt Formulas that get installed per RPM belongs in this directory.
 
-For more information visit:
-https://github.com/SUSE/spacewalk/wiki/Using-Salt-formulas-with-SUSE-Manager
-https://github.com/SUSE/spacewalk/wiki/Writing-Salt-Formulas-for-SUSE-Manager
-https://github.com/SUSE/spacewalk/wiki/Salt-Formula-RPMs-for-SUSE-Manager
-https://github.com/SUSE/spacewalk/wiki/How-Salt-formulas-in-SUSE-Manager-work


### PR DESCRIPTION
…33341)

These links point to a private wiki and cannot be read by everbody.
Remove the links.