### PR TITLE
Add support for postgres-exporter

### DIFF
--- a/prometheus-exporters-formula/metadata/form.yml
+++ b/prometheus-exporters-formula/metadata/form.yml
@@ -1,7 +1,17 @@
 node_exporter:
   $type: group
 
-  node_exporter_enabled:
+  enabled:
     $type: boolean
     $default: True
 
+postgres_exporter:
+  $type: group
+
+  enabled:
+    $type: boolean
+    $default: False
+
+  data_source_name:
+    $type: text
+    $default: postgresql://user:passwd@localhost:5432/database?sslmode=disable

--- a/prometheus-exporters-formula/metadata/pillar.example
+++ b/prometheus-exporters-formula/metadata/pillar.example
@@ -1,3 +1,6 @@
 node_exporter:
-  node_exporter_enabled: True
+  enabled: True
 
+postgres_exporter:
+  enabled: False
+  data_source_name: postgresql://user:passwd@localhost:5432/database?sslmode=disable

--- a/prometheus-exporters-formula/prometheus-exporters/config.sls
+++ b/prometheus-exporters-formula/prometheus-exporters/config.sls
@@ -1,0 +1,16 @@
+{% from "prometheus-exporters/map.jinja" import exporters with context %}
+
+{% if salt['pillar.get']('postgres_exporter:enabled', False) %}
+postgres_exporter_config:
+  file.managed:
+    - name: {{ exporters.postgres_exporter_service_config }}
+    - source: {{ 'salt://prometheus-exporters/files/postgres-exporter-config' }}
+    - makedirs: True
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - watch_in:
+      - service: postgres-exporter
+{% endif %}
+

--- a/prometheus-exporters-formula/prometheus-exporters/files/postgres-exporter-config
+++ b/prometheus-exporters-formula/prometheus-exporters/files/postgres-exporter-config
@@ -1,0 +1,9 @@
+## Path:           Applications/PostgreSQLExporter
+## Description:    Prometheus exporter for PostgreSQL
+## Type:           string()
+## Default:        "postgresql://user:passwd@localhost:5432/database?sslmode=disable"
+## ServiceRestart: postgres-exporter
+#
+# Connection URL to postgresql instance
+#
+DATA_SOURCE_NAME="{{ salt['pillar.get']('postgres_exporter:data_source_name', 'postgresql://user:passwd@localhost:5432/database?sslmode=disable') }}"

--- a/prometheus-exporters-formula/prometheus-exporters/init.sls
+++ b/prometheus-exporters-formula/prometheus-exporters/init.sls
@@ -1,9 +1,12 @@
 {% from "prometheus-exporters/map.jinja" import exporters with context %}
 
+include:
+  - prometheus-exporters.config
+
 node_exporter:
   pkg.installed:
     - name: {{ exporters.node_exporter_package }}
-{% if salt['pillar.get']('node_exporter:node_exporter_enabled', True) %}
+{% if salt['pillar.get']('node_exporter:enabled', True) %}
   service.running:
     - name: {{ exporters.node_exporter_service }}
     - enable: True
@@ -12,6 +15,21 @@ node_exporter:
 {% else %}
   service.dead:
     - name: {{ exporters.node_exporter_service }}
+    - enable: False
+{% endif %}
+
+postgres_exporter:
+  pkg.installed:
+    - name: {{ exporters.postgres_exporter_package }}
+{% if salt['pillar.get']('postgres_exporter:enabled', False) %}
+  service.running:
+    - name: {{ exporters.postgres_exporter_service }}
+    - enable: True
+    - require:
+      - pkg: postgres_exporter
+{% else %}
+  service.dead:
+    - name: {{ exporters.postgres_exporter_service }}
     - enable: False
 {% endif %}
 

--- a/prometheus-exporters-formula/prometheus-exporters/map.jinja
+++ b/prometheus-exporters-formula/prometheus-exporters/map.jinja
@@ -2,10 +2,16 @@
     'Suse': {
         'node_exporter_package': 'golang-github-prometheus-node_exporter',
         'node_exporter_service': 'prometheus-node_exporter',
+        'postgres_exporter_package': 'golang-github-wrouesnel-postgres_exporter',
+        'postgres_exporter_service': 'postgres-exporter',
+        'postgres_exporter_service_config': '/etc/sysconfig/postgres-exporter',
     },
     'Ubuntu': {
         'node_exporter_package': 'prometheus-node-exporter',
         'node_exporter_service': 'prometheus-node-exporter',
+        'postgres_exporter_package': 'prometheus-postgres-exporter',
+        'postgres_exporter_service': 'prometheus-postgres-exporter',
+        'postgres_exporter_service_config': '/etc/default/prometheus-postgres-exporter',
     },
 }, merge=salt['pillar.get']('exporters:lookup')) %}
 


### PR DESCRIPTION
This patch adds support for installing, enabling and configuring the `postgres-exporter` to the `prometheus-exporters-formula`.