### PR TITLE
Rename the postgres exporter service

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters/map.jinja
+++ b/prometheus-exporters-formula/prometheus-exporters/map.jinja
@@ -3,8 +3,8 @@
         'node_exporter_package': 'golang-github-prometheus-node_exporter',
         'node_exporter_service': 'prometheus-node_exporter',
         'postgres_exporter_package': 'golang-github-wrouesnel-postgres_exporter',
-        'postgres_exporter_service': 'postgres-exporter',
-        'postgres_exporter_service_config': '/etc/sysconfig/postgres-exporter',
+        'postgres_exporter_service': 'prometheus-postgres_exporter',
+        'postgres_exporter_service_config': '/etc/sysconfig/prometheus-postgres_exporter',
     },
     'Ubuntu': {
         'node_exporter_package': 'prometheus-node-exporter',


### PR DESCRIPTION
With our latest packages the service is named `prometheus-postgres_exporter`, the salt state needs to follow this change.