### PR TITLE
Fix issue with default grub line entry and refactor refactor state

### DIFF
--- a/cpu-mitigations-formula/states/map.jinja
+++ b/cpu-mitigations-formula/states/map.jinja
@@ -5,10 +5,5 @@
     'Off'            : 'mitigations=off',
     'Manual'         : '',
     },
-   'grub_line': {
-    'default'        : 'GRUB_CMDLINE_LINUX_DEFAULT',
-    '15'             : 'GRUB_CMDLINE_LINUX_DEFAULT',
-    '12'             : 'GRUB_CMDLINE_LINUX',
-    },
   }
 %}


### PR DESCRIPTION
There was an issue with the sumaform image sp3 , So the option should end with the _DEFAULT... 

(This option is a grub option and not a specific to SUSE).  

I also refactored some of the state so it's cleaner.   