### PR TITLE
Add support for centos and RHEL systems

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters/map.jinja
+++ b/prometheus-exporters-formula/prometheus-exporters/map.jinja
@@ -15,5 +15,13 @@
         'postgres_exporter_service': 'prometheus-postgres-exporter',
         'postgres_exporter_service_config': '/etc/default/prometheus-postgres-exporter',
     },
+    'RedHat': {
+        'node_exporter_package': 'golang-github-prometheus-node_exporter',
+        'node_exporter_service': 'prometheus-node_exporter',
+        'node_exporter_service_config': '/etc/sysconfig/prometheus-node_exporter',
+        'postgres_exporter_package': 'golang-github-wrouesnel-postgres_exporter',
+        'postgres_exporter_service': 'prometheus-postgres_exporter',
+        'postgres_exporter_service_config': '/etc/sysconfig/prometheus-postgres_exporter',
+    },
 }, merge=salt['pillar.get']('exporters:lookup')) %}
 


### PR DESCRIPTION
This patch adds support for systems with `os_family = RedHat` (centos and RHEL) for `prometheus-exporters-formula`.