### PR TITLE
Make bind options structure optional

### DIFF
--- a/bind-formula/bind-formula.changes
+++ b/bind-formula/bind-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  3 15:56:55 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
+
+- Bind form update - make options pillar optional.
+  * fixes problem with empty options introduced in previous version
+
+-------------------------------------------------------------------
 Tue Sep 24 14:03:48 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 0.1.1569489047.99c648b

--- a/bind-formula/form.yml
+++ b/bind-formula/form.yml
@@ -5,6 +5,7 @@ bind:
     $type: group
     options:
       $type: edit-group
+      $optional: True
       $prototype:
         $type: text
         $key:


### PR DESCRIPTION
- fix for removed default (introduced in 8392e6e938). When options
  were missing, pillar was generated as an empty string which then
  fails on state apply