### PR TITLE
Fix missing EFI path on non-SLE systems

### DIFF
--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct  3 16:01:42 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix missing EFI path on non-SLE systems
+
+-------------------------------------------------------------------
 Wed Sep  4 09:07:07 UTC 2019 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Update to version 0.1.1568808472.be9f236

--- a/pxe-formula/pxe/map.jinja
+++ b/pxe-formula/pxe/map.jinja
@@ -25,17 +25,15 @@
       'path_pxelinux':      '/usr/share/syslinux/pxelinux.0',
       'pathname_defcfg_efi': pxeroot + '/boot/pxelinux.cfg/default.grub2.cfg',
       'boot_efi':           pxeroot + '/boot/grub.efi',
+      'path_efi':           '/usr/share/grub2/x86_64-efi/grub.efi',
       'pathname_basecfg_efi': pxeroot + '/boot/grub.cfg',
-      'boot_efi_dir':       pxeroot + '/boot/x86_64-efi'
+      'boot_efi_dir':       pxeroot + '/boot/x86_64-efi',
+      'path_efi_dir':       '/usr/share/grub2/x86_64-efi'
     }
   }, merge=salt['grains.filter_by']({
     'SLES-12': {
       'path_efi':           '/usr/lib/grub2/x86_64-efi/grub.efi',
       'path_efi_dir':       '/usr/lib/grub2/x86_64-efi'
-    },
-    'SLES-15': {
-      'path_efi':           '/usr/share/grub2/x86_64-efi/grub.efi',
-      'path_efi_dir':       '/usr/share/grub2/x86_64-efi'
     }
   }, grain='osfinger'))
 %}


### PR DESCRIPTION
- Leap15 shares SLE15 paths so make them default and only check for SLE12
- This enables pxe formula for Uyuni