### PR TITLE
Use absolute paths in grub2 config

### DIFF
--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 16 12:22:35 UTC 2019 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Use absolute paths in grub2 config
+
+-------------------------------------------------------------------
 Thu Oct  3 16:01:42 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Fix missing EFI path on non-SLE systems

--- a/pxe-formula/pxe/files/pxecfg.grub2.template
+++ b/pxe-formula/pxe/files/pxecfg.grub2.template
@@ -14,9 +14,9 @@
 default=0
 timeout=1
 menuentry netboot {
-        linux boot/{{ kernel }} {{ salt['pillar.get']('pxe:default_kernel_parameters', '') }} MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
+        linux /boot/{{ kernel }} {{ salt['pillar.get']('pxe:default_kernel_parameters', '') }} MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
 {{-            ' root=' + pillar['root'] if salt['pillar.get']('root') else '' }}
 {{-            ' salt_device=' + pillar['salt_device'] if salt['pillar.get']('salt_device') else '' }}
 {{-            ' ' + salt['pillar.get']('terminal_kernel_parameters', '') }}
-        initrd boot/{{ initrd }}
+        initrd /boot/{{ initrd }}
 }


### PR DESCRIPTION
Relative paths do not work with USB. For PXE boot both work OK.