### PR TITLE
fix restart of service which is started via socket

### DIFF
--- a/tftpd-formula/tftpd/init.sls
+++ b/tftpd-formula/tftpd/init.sls
@@ -37,6 +37,24 @@ etc_sysconfig_tftp:
     - require:
       - pkg: install_tftp
       
+{% if cfgmap.deadservice != "" %}
+
+disable_tftp_service:
+  service.dead:
+    - name: {{ cfgmap.deadservice }}
+    - watch:
+        - file: etc_sysconfig_tftp
+
+enable_and_start_tftpd:
+  service.running:
+    - name: {{ cfgmap.servicename }}
+    - enable: True
+    - require:
+        - service: disable_tftp_service
+    - watch:
+        - file: etc_sysconfig_tftp
+
+{% else %}
 
 enable_and_start_tftpd:
   service.running:
@@ -44,3 +62,5 @@ enable_and_start_tftpd:
     - enable: True
     - watch:
         - file: etc_sysconfig_tftp
+
+{% endif %}

--- a/tftpd-formula/tftpd/map.jinja
+++ b/tftpd-formula/tftpd/map.jinja
@@ -21,6 +21,7 @@
       'package':      'tftp',
       'conflicting_package':      'atftp',
       'servicename':  'tftp.socket',
+      'deadservice':  'tftp.service',
       'pathname_cfg': '/etc/sysconfig/tftp'
     }
   })


### PR DESCRIPTION
When a service is started via socket, you cannot restart the socket
when the service was already started. So we turn the service down
to be able to restart the socket. 