### PR TITLE
Add support for new features in terminal naming

### DIFF
--- a/pxe-formula/form.yml
+++ b/pxe-formula/form.yml
@@ -21,8 +21,3 @@ pxe:
      $type: text
      $default: '/srv/saltboot'
 
-  branch_id:
-     $name: 'Branch Id'
-     $type: text
-     $placeholder: 'Enter unique Branch server ID (e.g. "B0001")'
-     $help: 'Branch server ID is used as a prefix in terminal ID'

--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 29 13:05:09 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add support for new features in terminal naming
+- Remove branch_id from pxe form, moved to branch-network form
+
+-------------------------------------------------------------------
 Wed Oct 16 12:22:35 UTC 2019 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Use absolute paths in grub2 config

--- a/pxe-formula/pxe/files/pxecfg.template
+++ b/pxe-formula/pxe/files/pxecfg.template
@@ -11,11 +11,25 @@
 {%-   endif %}
 {%- endif %}
 
+{%- set naming_config = '' %}
+{%- if salt['pillar.get']('pxe:disable_id_prefix') %}
+{%-   set naming_config = "DISABLE_ID_PREFIX=1" %}
+{%- endif %}
+{%- if salt['pillar.get']('pxe:disable_unique_suffix') %}
+{%-   set naming_config = naming_config + " DISABLE_UNIQUE_SUFFIX=1" %}
+{%- endif %}
+{%- set minion_id_naming = salt['pillar.get']('pxe:minion_id_naming', 'Hostname') %}
+{%- if minion_id_naming == 'FQDN' %}
+{%-   set naming_config = naming_config + " USE_FQDN_MINION_ID=1"  %}
+{%- elif minion_id_naming == 'HWType' %}
+{%-   set naming_config = naming_config + " DISABLE_HOSTNAME_ID=1" %}
+{%- endif %}
+
 DEFAULT netboot
 
 LABEL netboot
         kernel {{ kernel }}
-        append initrd={{ initrd }}  {{ salt['pillar.get']('pxe:default_kernel_parameters', '') }} MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
+        append initrd={{ initrd }}  {{ salt['pillar.get']('pxe:default_kernel_parameters', '') }} {{ naming_config }} MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
 {{-            ' root=' + pillar['root'] if salt['pillar.get']('root') else '' }}
 {{-            ' salt_device=' + pillar['salt_device'] if salt['pillar.get']('salt_device') else '' }}
 {{-            ' ' + salt['pillar.get']('terminal_kernel_parameters', '') }}


### PR DESCRIPTION
- new options for terminal naming now can be specified in pillars
  and this commit parse them to correctly set kernel command line
- branch_id field removed from pxe form and moved to branch-network