### PR TITLE
Add federation setup to Prometheus formula

### DIFF
--- a/prometheus-formula/metadata/form.yml
+++ b/prometheus-formula/metadata/form.yml
@@ -30,7 +30,7 @@ prometheus:
       $default: True
 
     autodiscover_clients:
-      $name: Autodiscover clients 
+      $name: Autodiscover clients
       $type: boolean
       $default: True
 
@@ -70,9 +70,9 @@ prometheus:
       $minItems: 0
       $itemName: Target ${i}
       $prototype:
-        $type: group 
+        $type: group
         $key:
-          $type: text 
+          $type: text
           $name: "IP Address : Port"
           $default: localhost:9093
           $match: "\\S*:\\d{1,5}"
@@ -85,6 +85,34 @@ prometheus:
         $default: /etc/prometheus/my-rules.yml
         $required: true
 
+  federation:
+    $type: edit-group
+    $name: Federation
+    $minItems: 0
+    $itemName: Prometheus server ${i}
+    $disabled: "!formValues.prometheus.enabled"
+    $prototype:
+      $type: group
+      $key:
+        $type: text
+        $name: "Job name"
+        $default: "federate"
+      match:
+        $type: edit-group
+        $minItems: 1
+        $name: "Metric name patterns"
+        $prototype:
+            $type: text
+            $default: "node:.*"
+      targets:
+        $type: edit-group
+        $minItems: 1
+        $itemName: Target ${i}
+        $prototype:
+          $type: text
+          $placeholder: "IP Address : Port"
+          $match: "\\S*:\\d{1,5}"
+
   scrape_configs:
     $type: edit-group
     $name: User defined scrape configurations
@@ -92,9 +120,9 @@ prometheus:
     $itemName: File-based service discovery ${i}
     $disabled: "!formValues.prometheus.enabled"
     $prototype:
-      $type: group 
+      $type: group
       $key:
-        $type: text 
+        $type: text
         $name: "Job name"
       files:
         $type: edit-group
@@ -103,5 +131,3 @@ prometheus:
           $type: text
           $default: /etc/prometheus/my-scrape-config.yml
           $required: true
-
-

--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 24 10:58:58 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Add federation configuration
+
+-------------------------------------------------------------------
 Mon Dec  9 16:32:11 UTC 2019 - malbu@suse.com
 
 - Bugfix: disabled fields not enabled when checkbox is checked

--- a/prometheus-formula/prometheus-formula.spec
+++ b/prometheus-formula/prometheus-formula.spec
@@ -19,7 +19,7 @@
 %define fname prometheus
 %define fdir  %{_datadir}/susemanager/formulas
 Name:           prometheus-formula
-Version:        0.1
+Version:        0.2
 Release:        0
 Summary:        Salt formula for installing and configuring Prometheus monitoring system
 License:        Apache-2.0

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: {{ salt['pillar.get']('prometheus:scrape_interval', 15) }}s 
+  scrape_interval: {{ salt['pillar.get']('prometheus:scrape_interval', 15) }}s
   evaluation_interval: {{ salt['pillar.get']('prometheus:evaluation_interval', 15) }}s
 
 {%- if salt['pillar.get']('prometheus:alerting:use_local_alertmanager', False) or salt['pillar.get']('prometheus:alerting:alertmanagers', None) %}
@@ -8,12 +8,12 @@ alerting:
   alertmanagers:
   - static_configs:
     - targets:
-{%- if salt['pillar.get']('prometheus:alerting:use_local_alertmanager', False) %}    
+{%- if salt['pillar.get']('prometheus:alerting:use_local_alertmanager', False) %}
       - localhost:9093
 {%- endif %}
-{%- for alertmanager in salt['pillar.get']('prometheus:alerting:alertmanagers', {}) %}   
+{%- for alertmanager in salt['pillar.get']('prometheus:alerting:alertmanagers', {}) %}
       - {{ alertmanager }}
-{%- endfor %}   
+{%- endfor %}
 {%- endif %}
 
 {%- if salt['pillar.get']('prometheus:alerting:rule_files', None) %}
@@ -48,7 +48,7 @@ scrape_configs:
 {%- endif %}
 {%- if salt['pillar.get']('prometheus:mgr:autodiscover_clients', False) %}
   # --------------------
-  # Auto discover clients of {{ grains['master'] }} 
+  # Auto discover clients of {{ grains['master'] }}
   # --------------------
   - job_name: 'mgr-clients'
     uyuni_sd_configs:
@@ -64,3 +64,23 @@ scrape_configs:
         - {{ file }}
 {% endfor %}
 {%- endfor %}
+{% for job, config in salt['pillar.get']('prometheus:federation').items() %}
+  {% if loop.first %}
+  # --------------------
+  # Federation
+  # --------------------
+  {% endif %}
+  - job_name: {{ job }}
+    honor_labels: true
+    metrics_path: '/{{ job }}'
+    params:
+      'match[]':
+        {% for pattern in config.match %}
+        - '{__name__=~"{{ pattern }}"}'
+        {% endfor %}
+    static_configs:
+      - targets:
+        {% for url in config.targets %}
+        - '{{ url }}'
+        {% endfor %}
+{% endfor %}


### PR DESCRIPTION
The change enables configuration of federated Prometheus setup. It assumes matching metric names according to to the specified list of matching patterns. The default is set to:

`{__name__=~"node:.*"}`

which matches all recording rules with the prefix `node:`. The corresponding recording rules have to be defined on the cluster's (e.g. CaaSP) Prometheus server.