### PR TITLE
Add meta monitoring for Prometheus

### DIFF
--- a/prometheus-formula/metadata/form.yml
+++ b/prometheus-formula/metadata/form.yml
@@ -65,6 +65,11 @@ prometheus:
       $visible: "this.parent.value.alertmanager_service"
       $default: True
 
+    default_rules:
+      $type: boolean
+      $default: True
+      $name: Enable default alerting rules
+
     alertmanagers:
       $type: edit-group
       $minItems: 0

--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 31 15:30:05 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Add meta-monitoring configuration
+
+-------------------------------------------------------------------
 Tue Mar 24 10:58:58 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 
 - Add federation configuration

--- a/prometheus-formula/prometheus/files/general-rules.yml
+++ b/prometheus-formula/prometheus/files/general-rules.yml
@@ -1,0 +1,12 @@
+groups:
+- name: general.rules
+  rules:
+  - alert: TargetDown
+    annotations:
+      message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.instance
+        }} instances are down.'
+    expr: 100 * (count(up == 0) BY (job, instance) / count(up) BY (job,
+      instance)) > 10
+    for: 10m
+    labels:
+      severity: warning

--- a/prometheus-formula/prometheus/files/prometheus-rules.yml
+++ b/prometheus-formula/prometheus/files/prometheus-rules.yml
@@ -1,0 +1,158 @@
+groups:
+- name: prometheus
+  rules:
+  - alert: PrometheusBadConfig
+    annotations:
+      description: Prometheus {{$labels.instance}} has failed to reload its
+        configuration.
+      summary: Failed Prometheus configuration reload.
+    expr: |
+      # Without max_over_time, failed scrapes could create false negatives, see
+      # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+      max_over_time(prometheus_config_last_reload_successful{job="prometheus"}[5m]) == 0
+    for: 10m
+    labels:
+      severity: critical
+  - alert: PrometheusNotificationQueueRunningFull
+    annotations:
+      description: Alert notification queue of Prometheus {{$labels.instance}}
+        is running full.
+      summary: Prometheus alert notification queue predicted to run full in less
+        than 30m.
+    expr: |
+      # Without min_over_time, failed scrapes could create false negatives, see
+      # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+      (
+        predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30)
+      >
+        min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m])
+      )
+    for: 15m
+    labels:
+      severity: warning
+  - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
+    annotations:
+      description: '{{ printf "%.1f" $value }}% errors while sending alerts from
+        Prometheus {{$labels.instance}} to Alertmanager {{$labels.alertmanager}}.'
+      summary: Prometheus has encountered more than 1% errors sending alerts to
+        a specific Alertmanager.
+    expr: |
+      (
+        rate(prometheus_notifications_errors_total{job="prometheus"}[5m])
+      /
+        rate(prometheus_notifications_sent_total{job="prometheus"}[5m])
+      )
+      * 100
+      > 1
+    for: 15m
+    labels:
+      severity: warning
+  - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
+    annotations:
+      description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts
+        from Prometheus {{$labels.instance}} to any Alertmanager.'
+      summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
+    expr: |
+      min without(alertmanager) (
+        rate(prometheus_notifications_errors_total{job="prometheus"}[5m])
+      /
+        rate(prometheus_notifications_sent_total{job="prometheus"}[5m])
+      )
+      * 100
+      > 3
+    for: 15m
+    labels:
+      severity: critical
+  - alert: PrometheusNotConnectedToAlertmanagers
+    annotations:
+      description: Prometheus {{$labels.instance}} is not connected
+        to any Alertmanagers.
+      summary: Prometheus is not connected to any Alertmanagers.
+    expr: |
+      # Without max_over_time, failed scrapes could create false negatives, see
+      # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+      max_over_time(prometheus_notifications_alertmanagers_discovered{job="prometheus"}[5m]) < 1
+    for: 10m
+    labels:
+      severity: warning
+  - alert: PrometheusTSDBReloadsFailing
+    annotations:
+      description: Prometheus {{$labels.instance}} has detected
+        {{$value | humanize}} reload failures over the last 3h.
+      summary: Prometheus has issues reloading blocks from disk.
+    expr: |
+      increase(prometheus_tsdb_reloads_failures_total{job="prometheus"}[3h]) > 0
+    for: 4h
+    labels:
+      severity: warning
+  - alert: PrometheusTSDBCompactionsFailing
+    annotations:
+      description: Prometheus {{$labels.instance}} has detected
+        {{$value | humanize}} compaction failures over the last 3h.
+      summary: Prometheus has issues compacting blocks.
+    expr: |
+      increase(prometheus_tsdb_compactions_failed_total{job="prometheus"}[3h]) > 0
+    for: 4h
+    labels:
+      severity: warning
+  - alert: PrometheusNotIngestingSamples
+    annotations:
+      description: Prometheus {{$labels.instance}} is not ingesting samples.
+      summary: Prometheus is not ingesting samples.
+    expr: |
+      rate(prometheus_tsdb_head_samples_appended_total{job="prometheus"}[5m]) <= 0
+    for: 10m
+    labels:
+      severity: warning
+  - alert: PrometheusDuplicateTimestamps
+    annotations:
+      description: Prometheus {{$labels.instance}} is dropping
+        {{ printf "%.4g" $value  }} samples/s with different values but duplicated
+        timestamp.
+      summary: Prometheus is dropping samples with duplicate timestamps.
+    expr: |
+      rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="prometheus"}[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+  - alert: PrometheusOutOfOrderTimestamps
+    annotations:
+      description: Prometheus {{$labels.instance}} is dropping
+        {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of order.
+      summary: Prometheus drops samples with out-of-order timestamps.
+    expr: |
+      rate(prometheus_target_scrapes_sample_out_of_order_total{job="prometheus"}[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+  - alert: PrometheusRuleFailures
+    annotations:
+      description: Prometheus {{$labels.instance}} has failed to evaluate 
+        {{ printf "%.0f" $value }} rules in the last 5m.
+      summary: Prometheus is failing rule evaluations.
+    expr: |
+      increase(prometheus_rule_evaluation_failures_total{job="prometheus"}[5m]) > 0
+    for: 15m
+    labels:
+      severity: critical
+  - alert: PrometheusMissingRuleEvaluations
+    annotations:
+      description: Prometheus {{$labels.instance}} has missed {{
+        printf "%.0f" $value }} rule group evaluations in the last 5m.
+      summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
+    expr: |
+      increase(prometheus_rule_group_iterations_missed_total{job="prometheus"}[5m]) > 0
+    for: 15m
+    labels:
+      severity: warning
+- name: general.rules
+  rules:
+  - alert: TargetDown
+    annotations:
+      message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.instance
+        }} instances are down.'
+    expr: 100 * (count(up == 0) BY (job, instance) / count(up) BY (job,
+      instance)) > 10
+    for: 10m
+    labels:
+      severity: warning

--- a/prometheus-formula/prometheus/files/prometheus-rules.yml
+++ b/prometheus-formula/prometheus/files/prometheus-rules.yml
@@ -145,14 +145,3 @@ groups:
     for: 15m
     labels:
       severity: warning
-- name: general.rules
-  rules:
-  - alert: TargetDown
-    annotations:
-      message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.instance
-        }} instances are down.'
-    expr: 100 * (count(up == 0) BY (job, instance) / count(up) BY (job,
-      instance)) > 10
-    for: 10m
-    labels:
-      severity: warning

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -16,12 +16,11 @@ alerting:
 {%- endfor %}
 {%- endif %}
 
-{%- if salt['pillar.get']('prometheus:alerting:rule_files', None) %}
 rule_files:
+  - /etc/prometheus/rules/prometheus-rules.yml
 {%- for rule_file in salt['pillar.get']('prometheus:alerting:rule_files', []) %}
   - {{ rule_file }}
 {%- endfor %}
-{%- endif %}
 
 # Scrape configurations
 scrape_configs:
@@ -64,23 +63,31 @@ scrape_configs:
         - {{ file }}
 {% endfor %}
 {%- endfor %}
+  # --------------------
+  # Metamonitoring
+  # --------------------
+  - job_name: prometheus
+    static_configs:
+      - targets:
+        - {{ grains['fqdn'] }}:9090
 {% for job, config in salt['pillar.get']('prometheus:federation').items() %}
-  {% if loop.first %}
+{% if loop.first %}
   # --------------------
   # Federation
   # --------------------
-  {% endif %}
+{% endif %}
   - job_name: {{ job }}
     honor_labels: true
     metrics_path: '/{{ job }}'
     params:
       'match[]':
-        {% for pattern in config.match %}
+        - '{job="prometheus"}'
+{% for pattern in config.match %}
         - '{__name__=~"{{ pattern }}"}'
-        {% endfor %}
+{% endfor %}
     static_configs:
       - targets:
-        {% for url in config.targets %}
+{% for url in config.targets %}
         - '{{ url }}'
-        {% endfor %}
+{% endfor %}
 {% endfor %}

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -17,7 +17,10 @@ alerting:
 {%- endif %}
 
 rule_files:
+{% if salt['pillar.get']('prometheus:alerting:default_rules', False) %}
+  - /etc/prometheus/rules/general-rules.yml
   - /etc/prometheus/rules/prometheus-rules.yml
+{% endif %}
 {%- for rule_file in salt['pillar.get']('prometheus:alerting:rule_files', []) %}
   - {{ rule_file }}
 {%- endfor %}

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -4,6 +4,7 @@
 # setup Prometheus
 {%- set monitor_server = salt['pillar.get']('prometheus:mgr:monitor_server', False) %}
 {%- set alertmanager_service = salt['pillar.get']('prometheus:alerting:alertmanager_service', False) %}
+{%- set default_rules = salt['pillar.get']('prometheus:alerting:default_rules', False) %}
 
 install_prometheus:
   pkg.installed:
@@ -25,10 +26,14 @@ config_file:
       - pkg: install_prometheus
       - pkg: install_alertmanager
 
-prometheus_rules_file:
+{% if default_rules %}
+default_rule_files:
   file.managed:
-    - name: /etc/prometheus/rules/prometheus-rules.yml
-    - source: salt://prometheus/files/prometheus-rules.yml
+    - names:
+      - /etc/prometheus/rules/prometheus-rules.yml:
+        - source: salt://prometheus/files/prometheus-rules.yml
+      - /etc/prometheus/rules/general-rules.yml:
+        - source: salt://prometheus/files/general-rules.yml
     - user: root
     - group: root
     - mode: 644
@@ -36,6 +41,7 @@ prometheus_rules_file:
     - require:
       - pkg: install_prometheus
       - pkg: install_alertmanager
+{% endif %}
 
 {%- if monitor_server %}
 mgr_scrape_config_file:
@@ -58,13 +64,17 @@ prometheus_running:
     - enable: True
     - require:
       - file: config_file
-      - file: prometheus_rules_file
+{% if default_rules %}
+      - file: default_rule_files
+{% endif %}
 {%- if monitor_server %}
       - file: mgr_scrape_config_file
 {%- endif %}
     - watch:
       - file: config_file
-      - file: prometheus_rules_file
+{% if default_rules %}
+      - file: default_rule_files
+{% endif %}
 {%- if monitor_server %}
       - file: mgr_scrape_config_file
 {%- endif %}

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -12,15 +12,27 @@ install_prometheus:
 install_alertmanager:
   pkg.installed:
     - name: {{ prometheus.alertmanager_package }}
-  
+
 config_file:
   file.managed:
-    - name: /etc/prometheus/prometheus.yml 
+    - name: /etc/prometheus/prometheus.yml
     - source: salt://prometheus/files/prometheus.yml
     - user: root
     - group: root
     - mode: 644
     - template: jinja
+    - require:
+      - pkg: install_prometheus
+      - pkg: install_alertmanager
+
+config_file:
+  file.managed:
+    - name: /etc/prometheus/rules/prometheus-rules.yml
+    - source: salt://prometheus/files/prometheus-rules.yml
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
     - require:
       - pkg: install_prometheus
       - pkg: install_alertmanager

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -25,7 +25,7 @@ config_file:
       - pkg: install_prometheus
       - pkg: install_alertmanager
 
-config_file:
+prometheus_rules_file:
   file.managed:
     - name: /etc/prometheus/rules/prometheus-rules.yml
     - source: salt://prometheus/files/prometheus-rules.yml
@@ -58,11 +58,13 @@ prometheus_running:
     - enable: True
     - require:
       - file: config_file
+      - file: prometheus_rules_file
 {%- if monitor_server %}
       - file: mgr_scrape_config_file
 {%- endif %}
     - watch:
       - file: config_file
+      - file: prometheus_rules_file
 {%- if monitor_server %}
       - file: mgr_scrape_config_file
 {%- endif %}


### PR DESCRIPTION
The change configures scraping Prometheus metrics from local and remote Prometheus instances and defines a set of default alerting rules based on these measurements.