### PR TITLE
Restart Grafana on configuration changes

### DIFF
--- a/grafana-formula/grafana-formula.changes
+++ b/grafana-formula/grafana-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  5 15:45:20 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Version 0.2.1
+- Restart Grafana when updating configuration
+
+-------------------------------------------------------------------
 Wed Mar 18 11:40:01 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 
 - Version 0.2

--- a/grafana-formula/grafana-formula.spec
+++ b/grafana-formula/grafana-formula.spec
@@ -19,7 +19,7 @@
 %define fname grafana
 %define fdir  %{_datadir}/susemanager/formulas
 Name:           grafana-formula
-Version:        0.2
+Version:        0.2.1
 Release:        0
 Summary:        Salt formula for installing and configuring Grafana
 License:        Apache-2.0

--- a/grafana-formula/grafana/init.sls
+++ b/grafana-formula/grafana/init.sls
@@ -101,10 +101,10 @@ grafana-server:
       - grafana
   service.running:
     - enable: True
-    - restart: True
-    - requires:
+    - watch_any:
       - file: /etc/grafana/provisioning/datasources/datasources.yml
       - file: /etc/grafana/provisioning/dashboards/dashboard-provider.yml
+      - file: /etc/grafana/provisioning/*/*.json
       - file: /etc/grafana/grafana.ini
 
 {%- else %}


### PR DESCRIPTION
When main configuration file or any of datasources or dashboards are
changed the service has to be restarted for changes to take effect. Modified formula watches for updates in these files to trigger restart.