### PR TITLE
virtualization host: misc fixes

### DIFF
--- a/virtualization-host-formula/metadata/form.yml
+++ b/virtualization-host-formula/metadata/form.yml
@@ -18,19 +18,19 @@ default_net_enabled:
 default_pool:
   $type: group
   $help: Configure the default storage pool
-  $visibleIf: default_pool_enabled == true
+  $visible: formValues.default_pool_enabled == true
 
   path:
     $type: text
     $name: Pool local path
     $default: /var/lib/libvirt/images
     $help: Path to the folder containing the disk images
-    $required: default_pool_enabled == true
+    $required: formValues.default_pool_enabled == true
 
 default_net:
   $type: group
   $help: Configure the default virtual network
-  $visibleIf: default_net_enabled == true
+  $visible: formValues.default_net_enabled == true
 
   mode:
     $type: select
@@ -41,14 +41,14 @@ default_net:
     $type: text
     $name: Bridge name
     $help: Name of the network bridge interface to use
-    $placeholder: br0
-    $visibleIf: default_net#mode == "Bridge"
-    $required: default_net#mode == "Bridge"
+    $default: br0
+    $visible: formValues.default_net.mode == 'Bridge'
+    $required: formValues.default_net.mode == 'Bridge'
 
   ipv4:
     $type: group
     $help: IPv4 settings
-    $visibleIf: default_net#mode == "NAT"
+    $visible: formValues.default_net.mode == 'NAT'
 
     gateway:
       $type: text
@@ -73,7 +73,7 @@ default_net:
   ipv6:
     $type: group
     $help: IPv6 settings
-    $visibleIf: default_net#mode == "NAT"
+    $visible: formValues.default_net.mode == 'NAT'
 
     gateway:
       $type: text

--- a/virtualization-host-formula/metadata/form.yml
+++ b/virtualization-host-formula/metadata/form.yml
@@ -35,7 +35,7 @@ default_net:
   mode:
     $type: select
     $values: ["NAT", "Bridge"]
-    $default: "NAT"
+    $default: "Bridge"
 
   bridge:
     $type: text

--- a/virtualization-host-formula/virtualization-host/init.sls
+++ b/virtualization-host-formula/virtualization-host/init.sls
@@ -43,6 +43,31 @@ default_pool:
 {% endif %}
 
 {% if pillar['default_net_enabled'] %}
+
+{% if pillar['default_net']['mode'] == "Bridge" %}
+
+# pick the first non-lo in grains['hwaddr_interfaces']
+{% set port = grains['hwaddr_interfaces']|reject('equalto', 'lo')|first() %}
+{% set nic = pillar['default_net']['bridge'] %}
+
+ifcfg-{{ port }}:
+  file.managed:
+    - name: /etc/sysconfig/network/ifcfg-{{ port }}
+    - contents: |
+        STARTMODE=auto
+        BOOTPROTO=none
+
+ifcfg-{{ nic }}:
+  file.managed:
+    - name: /etc/sysconfig/network/ifcfg-{{ nic }}
+    - contents: |
+        STARTMODE=onboot
+        BOOTPROTO=dhcp
+        BRIDGE=yes
+        BRIDGE_PORTS={{ port }}
+
+{% endif %}  {# if pillar['default_net']['mode'] == "Bridge" #}
+
 # We can't use the virt.network_running here since the IP patch isn't in 4.0's salt
 default-net.xml:
   file.managed:

--- a/virtualization-host-formula/virtualization-host/init.sls
+++ b/virtualization-host-formula/virtualization-host/init.sls
@@ -1,8 +1,15 @@
 {% from "virtualization-host/map.jinja" import packages with context %}
 
+# SLES JeOS doesn't ship the KVM and Xen modules
+no_kernel_default_base:
+  pkg.removed:
+    - name: kernel-default-base
+
 virthost_packages:
   pkg.installed:
     - pkgs: {{ packages }}
+    - require:
+        - pkg: no_kernel_default_base
 
 libvirtd_service:
   service.running:

--- a/virtualization-host-formula/virtualization-host/map.jinja
+++ b/virtualization-host-formula/virtualization-host/map.jinja
@@ -22,6 +22,7 @@
       'guestfs-tools',
       'libvirt-client',
       'python3-libvirt-python',
+      'kernel-default',
     ]
   %}
 {% endif %}

--- a/virtualization-host-formula/virtualization-host/map.jinja
+++ b/virtualization-host-formula/virtualization-host/map.jinja
@@ -21,6 +21,7 @@
       'qemu-tools',
       'guestfs-tools',
       'libvirt-client',
+      'python3-libvirt-python',
     ]
   %}
 {% endif %}


### PR DESCRIPTION
Squash a few virtualization host fixes in a PR.

Fixes:
  * SUSE/spacewalk#11953 (bridged default network)
  * SUSE/spacewalk#11996 (kernel-default)
  * Ensure we have python3 libvirt binding