### PR TITLE
uyuni-config-formula: fix spec typo

### DIFF
--- a/uyuni-config-formula/uyuni-config-formula.spec
+++ b/uyuni-config-formula/uyuni-config-formula.spec
@@ -28,7 +28,7 @@ Url:            https://github.com/SUSE/salt-formulas
 Source:         uyuni-config-formula-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Require:        uyuni-config-modules
+Requires:       uyuni-config-modules
 
 %description
 A formula to configure an Uyuni or SUSE Manager Server with organizations, users, groups and so on.


### PR DESCRIPTION
A small fix in the specfile