### PR TITLE
configration formula add support for activation keys

### DIFF
--- a/uyuni-config-formula/README.md
+++ b/uyuni-config-formula/README.md
@@ -7,3 +7,4 @@ This formula allows to define:
     * User groups
     * Access to system groups
     * Access to software channels
+* Activation keys

--- a/uyuni-config-formula/metadata/form.yml
+++ b/uyuni-config-formula/metadata/form.yml
@@ -120,3 +120,83 @@ uyuni:
             $prototype:
               $type: text
               $required: true
+
+      activation_keys:
+        $type: edit-group
+        $name: Activation Keys
+        $prototype:
+          name:
+            $type: text
+            $name: Name
+            $required: true
+          description:
+            $type: text
+            $name: Description
+            $required: true
+          base_channel:
+            $type: text
+            $name: Base Channel
+            $help: "Leave it black to use the default channel"
+          usage_limit:
+            $type: number
+            $name: Usage Limit
+            $help: "leave black or set to 0 for unlimited usage"
+          contact_method:
+            $type: select
+            $name: Contact method
+            $values: [ 'default',
+                       'ssh-push',
+                       'ssh-push-tunnel' ]
+            $default: 'default'
+            $required: false
+          universal_default:
+            $type: boolean
+            $name: Universal default
+            $default: False
+          configure_after_registration:
+            $type: boolean
+            $name: Configure after registration
+            $default: False
+            $help: "Deploy configuration files to systems on registration"
+          child_channels:
+            $type: edit-group
+            $name: Child Channels
+            $prototype:
+              $type: text
+              $required: true
+          configuration_channels:
+            $type: edit-group
+            $name: Configuration Channels
+            $prototype:
+              $type: text
+              $required: true
+          packages:
+            $type: edit-group
+            $name: packages
+            $prototype:
+              name:
+                $type: text
+                $name: Name
+                $required: true
+              arch:
+                $type: text
+                $name: Arch
+                $required: false
+          server_groups:
+            $type: edit-group
+            $name: Server groups
+            $prototype:
+              $type: text
+              $required: true
+          system_types:
+            $type: edit-group
+            $name: System types
+            $prototype:
+              # HACK limitation on the framework  which doesn't allow select directly on edit-groups.
+              # We have to add a sub-type to the array of system types, if we want to use a select
+              type:
+                $type: select
+                $values: ['virtualization_host',
+                        'container_build_host',
+                        'monitoring_entitled',
+                        'osimage_build_host']

--- a/uyuni-config-formula/metadata/pillar.example
+++ b/uyuni-config-formula/metadata/pillar.example
@@ -23,6 +23,26 @@ uyuni:
           system_groups: ['httpd_servers']
           manageable_channels : []
           subscribable_channels : []
+      activation_keys:
+        - name: my_key
+          description: My Activation Key created via formula
+          base_channel: sle-product-sles15-sp2-pool-x86_64
+          child_channels: ['sle-module-server-applications15-sp2-pool-x86_64']
+          configuration_channels: ['firewall']
+          packages:
+            - name: vim
+            - name: emacs
+              arch: x86_64
+          server_groups: ['httpd_servers']
+          usage_limit: 10
+          # HACK do to limitation on the form framework we had to have a list of objects, instead of a list o string.
+          # This was needed to allow the usage of select instead of free text.
+          system_types:
+            - type: 'virtualization_host'
+            - type: 'container_build_host'
+          contact_method: 'ssh-push'
+          universal_default: false
+          configure_after_registration: true
     - org_id: my_org
       org_admin_user: my_org_user
       org_admin_password: my_org_user

--- a/uyuni-config-formula/uyuni-config-formula.changes
+++ b/uyuni-config-formula/uyuni-config-formula.changes
@@ -1,3 +1,5 @@
+- Add support for configure Activation Keys
+
 -------------------------------------------------------------------
 Mon Aug 10 13:05:07 UTC 2020 - Ricardo Mateus <rmateus@suse.com>
 

--- a/uyuni-config-formula/uyuni-config/init.sls
+++ b/uyuni-config-formula/uyuni-config/init.sls
@@ -45,4 +45,33 @@ org_{{org['org_id']}}:
 
 {% endfor %}
 
+{% for ak in org.get('activation_keys', []) %}
+
+# HACK do to limitation on the form framework we had to have a list of objects, instead of a list o string.
+# This was needed to allow the usage of select instead of free text.
+# the next lines convert the system_types back to a list of strings, as expected on the salt stated
+{% set system_types = [] %}
+{% for ak in ak.get('system_types', []) %}
+    {% set system_types = system_types.append(ak['type']) %}
+{% endfor %}
+
+{{org['org_id']}}_{{ak['name']}}:
+  uyuni.activation_key_present:
+    - name: {{ak['name']}}
+    - description: {{ak['description']}}
+    - org_admin_user: {{org['org_admin_user']}}
+    - org_admin_password: {{org['org_admin_password']}}
+    - base_channel: {{ak['base_channel']}}
+    - child_channels: {{ak['child_channels']}}
+    - configuration_channels: {{ak['configuration_channels']}}
+    - packages: {{ak['packages']}}
+    - server_groups: {{ak['server_groups']}}
+    - usage_limit: {{ak['usage_limit']}}
+    - system_types: {{system_types}}
+    - contact_method: {{ak['contact_method']}}
+    - universal_default: {{ak.get('universal_default', false)}}
+    - configure_after_registration: {{ak.get('configure_after_registration', false)}}
+
+{% endfor %}
+
 {% endfor %}


### PR DESCRIPTION
Update salt uyuni configuration formula to allow manage activation keys

Part of: https://github.com/SUSE/spacewalk/issues/12495

Signed-off-by: Ricardo Mateus <rmateus@suse.com>