### PR TITLE
Change default to initrd without .gz suffix

### DIFF
--- a/pxe-formula/form.yml
+++ b/pxe-formula/form.yml
@@ -9,7 +9,7 @@ pxe:
   initrd_name:
      $name: 'Initrd Filename'
      $type: text
-     $default: 'initrd.gz'
+     $default: 'initrd'
 
   default_kernel_parameters:
      $name: 'Kernel Command Line Parameters'

--- a/pxe-formula/pillar.example
+++ b/pxe-formula/pillar.example
@@ -1,7 +1,7 @@
 # from salt form:
 branchserver:
   kernel_name: 'linux'
-  initrd_name: 'initrd.gz'
+  initrd_name: 'initrd'
   default_kernel_parameters: 'panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=1'
 
 

--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct  8 13:50:59 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Change default to "initrd" without .gz suffix
+
+-------------------------------------------------------------------
 Tue Apr 14 14:10:16 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Add non-EFI grub menu variant

--- a/pxe-formula/pxe/files/pxecfg.grub2.template
+++ b/pxe-formula/pxe/files/pxecfg.grub2.template
@@ -1,5 +1,5 @@
 {%- set kernel = salt['pillar.get']('pxe:kernel_name', 'linux') %}
-{%- set initrd = salt['pillar.get']('pxe:initrd_name', 'initrd.gz') %}
+{%- set initrd = salt['pillar.get']('pxe:initrd_name', 'initrd') %}
 {%- set boot_image = 'boot_images:' + salt['pillar.get']('boot_image', 'default') %}
 {%- if salt['pillar.get'](boot_image) %}
 {%-   set kernel = salt['pillar.get'](boot_image + ':kernel:url', '').split('/')[-1] %}

--- a/pxe-formula/pxe/files/pxecfg.template
+++ b/pxe-formula/pxe/files/pxecfg.template
@@ -1,5 +1,5 @@
 {%- set kernel = salt['pillar.get']('pxe:kernel_name', 'linux') %}
-{%- set initrd = salt['pillar.get']('pxe:initrd_name', 'initrd.gz') %}
+{%- set initrd = salt['pillar.get']('pxe:initrd_name', 'initrd') %}
 {%- set boot_image = 'boot_images:' + salt['pillar.get']('boot_image', 'default') %}
 {%- if salt['pillar.get'](boot_image) %}
 {%-   set kernel = salt['pillar.get'](boot_image + ':kernel:url', '').split('/')[-1] %}


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/12162
Depends on https://github.com/uyuni-project/retail/pull/64