### PR TITLE
Disable Prometheus exporters' reverse proxy (#82)

### DIFF
--- a/prometheus-exporters-formula/metadata/pillar.example
+++ b/prometheus-exporters-formula/metadata/pillar.example
@@ -1,4 +1,4 @@
-proxy_enabled: True
+proxy_enabled: False
 proxy_port: 9999
 
 node_exporter:

--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Oct  5 10:04:04 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Disable reverse proxy on default
+
+-------------------------------------------------------------------
 Fri Oct  2 07:44:37 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 
 - Version 0.7.4


### PR DESCRIPTION
Reverse proxy for Prometheus should get installed only when actively
activated by the user. It assures the backwards compatibility with
existing deployments.

(cherry picked from commit 64b891aeb2de0d0ea5c4e921c824df21df395fd3)