### PR TITLE
Remove empty dictionary values initialization

### DIFF
--- a/prometheus-exporters-formula/metadata/pillar.example
+++ b/prometheus-exporters-formula/metadata/pillar.example
@@ -9,10 +9,8 @@ node_exporter:
 apache_exporter:
   enabled: False
   address: ':9117'
-  args:
 
 postgres_exporter:
   enabled: False
   address: ':9187'
   data_source_name: postgresql://user:passwd@localhost:5432/database?sslmode=disable
-  args:

--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Tue Oct 13 11:55:01 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Version 0.8.0
+- Fix empty directory values initialization
+
+-------------------------------------------------------------------
 Thu Oct  8 13:23:59 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
 
-- Version 0.8.0:
 - Add systemd collector as default for node_exporters
-  since otherwise some SAP/HA grafana dashboards will be empty  
+  since otherwise some SAP/HA grafana dashboards will be empty
+
 -------------------------------------------------------------------
 Mon Oct  5 10:04:04 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 


### PR DESCRIPTION
When default values are used for initialization of formula data, empty
dictionary values are serialized as null objects. This causes
NullPointerException in Xml Serializer of FormulaData object on the
server side.

Fixes: https://github.com/uyuni-project/uyuni/issues/2651