### PR TITLE
Temporarily disable dnssec-validation as hotfix for bsc#1177790

### DIFF
--- a/bind-formula/bind-formula.changes
+++ b/bind-formula/bind-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Oct 20 11:21:05 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Temporarily disable dnssec-validation as hotfix for bsc#1177790
+
+-------------------------------------------------------------------
 Thu Oct  3 15:56:55 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Bind form update - make options pillar optional.

--- a/bind-formula/bind/files/suse/named.conf
+++ b/bind-formula/bind/files/suse/named.conf
@@ -39,7 +39,7 @@ options {
 	# (containing one or more trusted-anchors or a managed-keys clause.
 
 	#dnssec-validation auto;
-	managed-keys-directory "/var/lib/named/dyn/";
+	managed-keys-directory "{{ map.get('named_directory') }}/dyn/";
 
 	# Write dump and statistics file to the log subdirectory.  The
 	# pathenames are relative to the chroot jail.
@@ -111,6 +111,8 @@ options {
     {%- endif %}
 {%- endfor %}
 
+        #disable dnssec-validation as hotfix for bsc#1177790
+        dnssec-validation no;
 };
 
 # The following zone definitions don't need any modification.  The first one


### PR DESCRIPTION
Once SUMA formula rendering is enhanced to cope with list of values mixed together with predefined values I'll revert this fix and use proper form.yml.