### PR TITLE
Add IP or empty string match for tftp formula

### DIFF
--- a/tftpd-formula/form.yml
+++ b/tftpd-formula/form.yml
@@ -5,6 +5,8 @@ tftpd:
      $name: 'Internal Network Address'
      $type: text
      $optional: True
+     $match: '(^$)|(^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$)'
+     $help: 'IPv4 address TFTP server should listen on. Empty value means 0.0.0.0'
 
   root_dir:
      $name: 'TFTP base directory'

--- a/tftpd-formula/tftpd-formula.changes
+++ b/tftpd-formula/tftpd-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec  2 17:04:29 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
+
+- Add IP or empty string match for network address field
+
+-------------------------------------------------------------------
 Thu May 23 13:54:24 UTC 2019 - Ondrej Holecek <oholecek@suse.com>
 
 - Updated copyrights and bug reporting link


### PR DESCRIPTION
I was contacted that customer was surprised tftp formula now requires entering an IP address. There was not a change in behaviour and customer probably had a space in the formula field.
Here I'm adding a match check to check either completely empty value or correct IP address.