### PR TITLE
[prometheus] Set server hostname from pillar data

### DIFF
--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Feb  5 12:50:31 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
+
+- Set server hostname from pillar data (bsc#1180439)
+
+-------------------------------------------------------------------
 Thu Oct 29 12:00:47 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 
 - Update to version 0.3.0

--- a/prometheus-formula/prometheus/files/mgr-server.yml
+++ b/prometheus-formula/prometheus/files/mgr-server.yml
@@ -1,10 +1,10 @@
 - targets:
-  - {{ grains['master'] }}:9100
-  - {{ grains['master'] }}:5556
-  - {{ grains['master'] }}:5557
-  - {{ grains['master'] }}:9800
+  - {{ uyuni_server_hostname }}:9100
+  - {{ uyuni_server_hostname }}:5556
+  - {{ uyuni_server_hostname }}:5557
+  - {{ uyuni_server_hostname }}:9800
   labels: {}
 - targets:
-  - {{ grains['master'] }}:9187
+  - {{ uyuni_server_hostname }}:9187
   labels:
     role: postgres

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -32,22 +32,22 @@ rule_files:
 scrape_configs:
 {%- if salt['pillar.get']('prometheus:mgr:monitor_server', False) %}
   # --------------------
-  # Monitor {{ grains['master'] }}
+  # Monitor {{ uyuni_server_hostname }}
   # --------------------
   - job_name: 'mgr-server'
     static_configs:
       - targets:
-        - {{ grains['master'] }}:9100 # Node exporter
-        - {{ grains['master'] }}:5556 # Tomcat JMX
-        - {{ grains['master'] }}:5557 # Taskomatic JMX
-        - {{ grains['master'] }}:9800 # Uyuni server exporter
+        - {{ uyuni_server_hostname }}:9100 # Node exporter
+        - {{ uyuni_server_hostname }}:5556 # Tomcat JMX
+        - {{ uyuni_server_hostname }}:5557 # Taskomatic JMX
+        - {{ uyuni_server_hostname }}:9800 # Uyuni server exporter
         labels: {}
       - targets:
-        - {{ grains['master'] }}:80 # Message queue
+        - {{ uyuni_server_hostname }}:80 # Message queue
         labels:
           __metrics_path__: /rhn/metrics
       - targets:
-        - {{ grains['master'] }}:9187 # PostgresSQL
+        - {{ uyuni_server_hostname }}:9187 # PostgresSQL
         labels:
           role: postgres
 {%- endif %}
@@ -56,7 +56,7 @@ scrape_configs:
 {%- if salt['pillar.get']('prometheus:mgr:autodiscover_clients', False) and
        sd_username and sd_password %}
   # --------------------
-  # Auto discover clients of {{ grains['master'] }}
+  # Auto discover clients of {{ uyuni_server_hostname }}
   # --------------------
   - job_name: 'mgr-clients'
     uyuni_sd_configs:

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -5,6 +5,7 @@
 {%- set monitor_server = salt['pillar.get']('prometheus:mgr:monitor_server', False) %}
 {%- set alertmanager_service = salt['pillar.get']('prometheus:alerting:alertmanager_service', False) %}
 {%- set default_rules = salt['pillar.get']('prometheus:alerting:default_rules', False) %}
+{%- set uyuni_server_hostname = salt['pillar.get']('mgr_origin_server', grains['master'])%}
 
 install_prometheus:
   pkg.installed:
@@ -25,6 +26,8 @@ config_file:
     - require:
       - pkg: install_prometheus
       - pkg: install_alertmanager
+    - defaults:
+        uyuni_server_hostname: {{ uyuni_server_hostname }}
 
 {% if default_rules %}
 default_rule_files:
@@ -56,6 +59,8 @@ mgr_scrape_config_file:
     - require:
       - pkg: install_prometheus
       - pkg: install_alertmanager
+    - defaults:
+        uyuni_server_hostname: {{ uyuni_server_hostname }}
 {%- endif %}
 
 prometheus_running:

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -27,7 +27,7 @@ config_file:
       - pkg: install_prometheus
       - pkg: install_alertmanager
     - defaults:
-        uyuni_server_hostname: {{ uyuni_server_hostname }}
+      uyuni_server_hostname: {{ uyuni_server_hostname }}
 
 {% if default_rules %}
 default_rule_files:
@@ -60,7 +60,7 @@ mgr_scrape_config_file:
       - pkg: install_prometheus
       - pkg: install_alertmanager
     - defaults:
-        uyuni_server_hostname: {{ uyuni_server_hostname }}
+      uyuni_server_hostname: {{ uyuni_server_hostname }}
 {%- endif %}
 
 prometheus_running:


### PR DESCRIPTION
When the minion with Prometheus server is registered on the proxy and
not directly on the Uyuni server, Prometheus should be configured with
Uyuni server hostname and not Salt master which is set to proxy minion
in this setup.

Fixes SUSE/spacewalk#13543