### PR TITLE
Use linuxefi only on x86

### DIFF
--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 29 13:19:23 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Use linuxefi only on x86
+
+-------------------------------------------------------------------
 Thu Oct  8 13:50:59 UTC 2020 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Change default to "initrd" without .gz suffix

--- a/pxe-formula/pxe/files/pxecfg.grub2.template
+++ b/pxe-formula/pxe/files/pxecfg.grub2.template
@@ -27,7 +27,7 @@
 
 default=0
 timeout=1
-if test "${grub_platform}" = "efi"; then
+if test "${grub_platform}" = "efi" -a ( "${grub_cpu}" = "x86_64" -o "${grub_cpu}" = "i386" ) ; then
 menuentry netboot {
         linuxefi ${prefix}/{{ kernel }} {{ salt['pillar.get']('pxe:default_kernel_parameters', '') }} {{ naming_config }} MINION_ID_PREFIX={{ salt['pillar.get']('pxe:branch_id', 'UnknownBranch') }}
 {{-            ' root=' + pillar['root'] if salt['pillar.get']('root') else '' }}


### PR DESCRIPTION
linuxefi grub command does not work on arm, this change is copied from Kiwi OEM image configuration.