### PR TITLE
[prometheus-exporters] Fix exporter exporter configuration

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,3 +1,5 @@
+- Fix exporter exporter modules configuration
+
 -------------------------------------------------------------------
 Wed Jun  9 10:49:02 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-exporters-formula/prometheus-exporters/files/exporter-proxy.yaml
+++ b/prometheus-exporters-formula/prometheus-exporters/files/exporter-proxy.yaml
@@ -1,4 +1,4 @@
-{% set exporter_address = salt['pillar.get'](module ~ '_exporter:address') %}
+{% set exporter_address = salt['pillar.get']('exporters:' ~ module ~ '_exporter:address') %}
 {% set exporter_port = exporter_address.rsplit(':')[-1] %}
 {% set exporter_host = exporter_address.split(':')[0] %}
 

--- a/prometheus-exporters-formula/prometheus-exporters/init.sls
+++ b/prometheus-exporters-formula/prometheus-exporters/init.sls
@@ -106,7 +106,7 @@ node_exporter:
 {% if node_exporter_enabled and proxy_enabled and proxy_supported %}
 node_exporter_proxy:
     file.managed:
-      - name: /etc/exporter_exporter.d/node.yaml
+      - name: /etc/exporter_exporter.d/node_exporter.yaml
       - source: salt://prometheus-exporters/files/exporter-proxy.yaml
       - template: jinja
       - context:
@@ -162,7 +162,7 @@ apache_exporter:
 {% if apache_exporter_enabled and proxy_enabled and proxy_supported %}
 apache_exporter_proxy:
   file.managed:
-    - name: /etc/exporter_exporter.d/apache.yaml
+    - name: /etc/exporter_exporter.d/apache_exporter.yaml
     - source: salt://prometheus-exporters/files/exporter-proxy.yaml
     - template: jinja
     - context:
@@ -218,7 +218,7 @@ postgres_exporter:
 {% if postgres_exporter_enabled and proxy_enabled and proxy_supported %}
 postgres_exporter_proxy:
   file.managed:
-    - name: /etc/exporter_exporter.d/postgres.yaml
+    - name: /etc/exporter_exporter.d/postgres_exporter.yaml
     - source: salt://prometheus-exporters/files/exporter-proxy.yaml
     - template: jinja
     - context:


### PR DESCRIPTION
In the new formula data schema exporters' configuration has been moved
to `exporters` field.

Also, full [exporter key name](https://github.com/uyuni-project/prometheus-uyuni-sd/commit/1eb8cf162a9ee166083a24704c51ea74c28406df#diff-7c95b54a215ed562472b3db7123a8cbf788db6f9f08d6b74adcfd6b8f0d28d74R261) is used for the module name now.
