### PR TITLE
[prometheus-exporters] Fix missing exporter in formula data migration

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,3 +1,5 @@
+- Fix formula data migration with missing exporter configuration (bsc#1188136)
+
 -------------------------------------------------------------------
 Fri Jul  2 13:11:55 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-exporters-formula/scripts/migrate_formula_data.py
+++ b/prometheus-exporters-formula/scripts/migrate_formula_data.py
@@ -42,7 +42,8 @@ class Migration:
     def migrate_from_version_1(self):
         exporters = self.data['exporters'] = {}
         for exporter in v1_keys:
-            exporters[exporter] = self.data.pop(exporter)
+            if exporter in self.data:
+                exporters[exporter] = self.data.pop(exporter)
 
     def fix_schema(self):
         none_value_to_empty_string(self.data)


### PR DESCRIPTION
Fix formula data migration script to handle the case when one of exporter configuration dictionaries is missing.

Steps to reproduce:

Run the migration script with the following formula data:

```
{
  "node_exporter": {
    "enabled": true,
    "args": "--web.listen-address\u003d\":9100\""
  },
  "postgres_exporter": {
    "enabled": false,
    "data_source_name": "postgresql://user:passwd@localhost:5432/database?sslmode\u003ddisable",
    "args": "--web.listen-address\u003d\":9187\""
  }
}
```

Fixes: https://github.com/SUSE/spacewalk/issues/15350