### PR TITLE
Open Prometheus ports on proxy

### DIFF
--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,5 @@
+- Open Prometheus ports (bsc#1191144)
+
 -------------------------------------------------------------------
 Wed Jul  7 08:36:19 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -13,6 +13,15 @@ install_prometheus:
   pkg.installed:
     - name: {{ prometheus.prometheus_package }}
 
+{% if grains['install_proxy_pattern'] %}
+firewall_prometheus:
+  firewalld.present:
+    - name: public
+    - prune_services: False
+    - services:
+      - prometheus
+{% endif %}
+
 install_alertmanager:
   pkg.installed:
     - name: {{ prometheus.alertmanager_package }}
@@ -145,6 +154,21 @@ alertmanager_running:
     - name: {{ prometheus.alertmanager_service }}
     - enable: False
 {%- endif %}
+
+{% if alertmanager_service and grains['install_proxy_pattern'] %}
+alertmanager_service:
+  firewalld.service:
+    - name: prometheus-alertmanager
+    - ports:
+      - 9093/tcp
+
+firewall_alertmanager:
+  firewalld.present:
+    - name: public
+    - prune_services: False
+    - services:
+      - prometheus-alertmanager
+{% endif %}
 
 {%- else %}
 # remove prometheus


### PR DESCRIPTION
The change opens Prometheus server and Prometheus Alertmanager ports in case the components are being installed on the proxy system.

Fixes SUSE/spacewalk#15990