### PR TITLE
Add support for Prometheus>=2.31

### DIFF
--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,5 @@
+- Add support for new Uyuni SD in Prometheus>=2.31
+
 -------------------------------------------------------------------
 Tue Oct 12 14:05:13 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,4 +1,4 @@
-- Add support for new Uyuni SD in Prometheus>=2.31
+  * Add support for new Uyuni SD in Prometheus >= 2.31
 
 -------------------------------------------------------------------
 Tue Oct 12 14:05:13 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -76,7 +76,11 @@ scrape_configs:
     relabel_configs:
       - source_labels: [__meta_uyuni_exporter]
         target_label: exporter
+      - source_labels: [__address__]
+        replacement: "No group"
+        target_label: groups
       - source_labels: [__meta_uyuni_groups]
+        regex: (.+)
         target_label: groups
       - source_labels: [__meta_uyuni_minion_hostname]
         target_label: hostname

--- a/prometheus-formula/prometheus/files/prometheus_old.yml
+++ b/prometheus-formula/prometheus/files/prometheus_old.yml
@@ -64,7 +64,7 @@ scrape_configs:
   # --------------------
   - job_name: 'mgr-clients'
     uyuni_sd_configs:
-      - server: https://{{ grains['master'] }}
+      - host: https://{{ grains['master'] }}
         username: {{ sd_username }}
         password: {{ sd_password }}
 {% if targets_tls.enabled %}
@@ -72,32 +72,12 @@ scrape_configs:
       ca_file: {{ targets_tls.ca_certificate }}
       cert_file: {{ targets_tls.client_certificate }}
       key_file: {{ targets_tls.client_key }}
-{% endif %}
     relabel_configs:
-      - source_labels: [__meta_uyuni_exporter]
-        target_label: exporter
-      - source_labels: [__meta_uyuni_groups]
-        target_label: groups
-      - source_labels: [__meta_uyuni_minion_hostname]
-        target_label: hostname
-      - source_labels: [__meta_uyuni_primary_fqdn]
-        regex: (.+)
-        target_label: hostname
-      - source_labels: [hostname, __address__]
-        regex: (.*);.*:(.*)
-        replacement: ${1}:${2}
-        target_label: __address__
-      - source_labels: [__meta_uyuni_metrics_path]
-        regex: (.+)
-        target_label: __metrics_path__
-      - source_labels: [__meta_uyuni_proxy_module]
-        target_label: __param_module
-{% if targets_tls.enabled %}
-      - source_labels: [__meta_uyuni_exporter]
-        regex: apache_exporter|postgres_exporter
-        target_label: __scheme__
-        replacement: http
-        action: replace
+    - source_labels: [exporter]
+      regex: apache_exporter|postgres_exporter
+      target_label: __scheme__
+      replacement: http
+      action: replace
 {% endif %}
 {%- endif %}
 {%- for job, files in salt['pillar.get']('prometheus:scrape_configs', {}).items() %}

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -27,10 +27,16 @@ install_alertmanager:
   pkg.installed:
     - name: {{ prometheus.alertmanager_package }}
 
+{% set prometheus_version = salt['pkg.version'](prometheus.prometheus_package) %}
+{% if salt['pkg.version_cmp'](prometheus_version, '2.31.0') >= 0 %}
+  {% set prometheus_config_template = prometheus.prometheus_config %}
+{% else %}
+  {% set prometheus_config_template = prometheus.prometheus_config_old %}
+{% endif %}
 config_file:
   file.managed:
     - name: /etc/prometheus/prometheus.yml
-    - source: salt://prometheus/files/prometheus.yml
+    - source: {{ prometheus_config_template }}
     - user: root
     - group: root
     - mode: 644

--- a/prometheus-formula/prometheus/map.jinja
+++ b/prometheus-formula/prometheus/map.jinja
@@ -6,6 +6,8 @@
         'prometheus_service': 'prometheus',
         'alertmanager_service': 'prometheus-alertmanager',
         'blackbox_exporter_service': 'prometheus-blackbox_exporter',
-        'blackbox_exporter_service_config': '/etc/systemd/system/prometheus-blackbox_exporter.service.d/uyuni.conf'
+        'blackbox_exporter_service_config': '/etc/systemd/system/prometheus-blackbox_exporter.service.d/uyuni.conf',
+        'prometheus_config': 'salt://prometheus/files/prometheus.yml',
+        'prometheus_config_old': 'salt://prometheus/files/prometheus_old.yml'
     },
 }, default='Suse') %}


### PR DESCRIPTION
Prometheus 2.31 includes upstream Uyuni SD with different configuration options and different set of returned labels.
This change checks the version of the installed Prometheus package and applies the appropriate configuration template to provide unchanged user experience.