### PR TITLE
[Manager-4.1] Fix Blackbox exporter configuration for Prometheus >= 2.31

### DIFF
--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,5 @@
+  * Fix Blackbox exporter configuration for Prometheus >= 2.31
+
 -------------------------------------------------------------------
 Wed Dec 22 13:29:37 UTC 2021 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -134,17 +134,24 @@ scrape_configs:
     params:
       module: [ssh_banner]
     uyuni_sd_configs:
-      - host: https://{{ grains['master'] }}
+      - server: https://{{ grains['master'] }}
         username: {{ sd_username }}
         password: {{ sd_password }}
     relabel_configs:
-     - source_labels: [hostname]
-       replacement: '${1}:22'
-       target_label: __param_target
-     - source_labels: [__param_target]
-       target_label: instance
-     - target_label: __address__
-       replacement: {{ grains['fqdn'] }}:9115
-     - target_label: exporter
-       replacement: ''
+      - source_labels: [__meta_uyuni_minion_hostname]
+        target_label: hostname
+      - source_labels: [__meta_uyuni_primary_fqdn]
+        regex: (.+)
+        target_label: hostname
+      - source_labels: [hostname]
+        replacement: '${1}:22'
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: {{ grains['fqdn'] }}:9115
+      - source_labels: [__meta_uyuni_groups]
+        target_label: groups
+      - target_label: exporter
+        replacement: ''
 {% endif %}

--- a/prometheus-formula/prometheus/files/prometheus_old.yml
+++ b/prometheus-formula/prometheus/files/prometheus_old.yml
@@ -117,13 +117,13 @@ scrape_configs:
         username: {{ sd_username }}
         password: {{ sd_password }}
     relabel_configs:
-     - source_labels: [hostname]
-       replacement: '${1}:22'
-       target_label: __param_target
-     - source_labels: [__param_target]
-       target_label: instance
-     - target_label: __address__
-       replacement: {{ grains['fqdn'] }}:9115
-     - target_label: exporter
-       replacement: ''
+      - source_labels: [hostname]
+        replacement: '${1}:22'
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: {{ grains['fqdn'] }}:9115
+      - target_label: exporter
+        replacement: ''
 {% endif %}


### PR DESCRIPTION
Update blackbox exporter configuration for Prometheus 2.32

(cherry picked from commit ee3bf947278496801b21f82bb1f3cf97821da3ff)

Fixes: https://github.com/SUSE/spacewalk/issues/16744