### PR TITLE
Allow prometheus-formula only for SUSE systems (#174)

### DIFF
--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,5 @@
+  * Allow prometheus-formula only for SUSE systems (bsc#1199149)
+
 -------------------------------------------------------------------
 Fri Feb 25 15:04:59 UTC 2022 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -1,5 +1,6 @@
 {% from "prometheus/map.jinja" import prometheus with context %}
 
+{%- if prometheus %}
 {%- if salt['pillar.get']('prometheus:enabled', False) %}
 # setup Prometheus
 {%- set monitor_server = salt['pillar.get']('prometheus:mgr:monitor_server', False) %}
@@ -200,4 +201,5 @@ remove_alertmanager:
       - pkg: remove_prometheus
       - pkg: remove_alertmanager
 
+{%- endif %}
 {%- endif %}

--- a/prometheus-formula/prometheus/map.jinja
+++ b/prometheus-formula/prometheus/map.jinja
@@ -10,4 +10,4 @@
         'prometheus_config': 'salt://prometheus/files/prometheus.yml',
         'prometheus_config_old': 'salt://prometheus/files/prometheus_old.yml'
     },
-}, default='Suse') %}
+}, merge=salt['pillar.get']('prometheus:lookup')) %}


### PR DESCRIPTION
Prometheus formula is currently supported only for SUSE systems.
The change hardens the formula to allow its application only to
supported systems. Additionally, the variables map can be extended by
the customer by setting the values in `prometheus:lookup` pillar.

(cherry picked from commit c71947edfc1e7e0cdfacab22053bcd11646eaff3)