### PR TITLE
[grafana] Fix default admin password field name

### DIFF
--- a/grafana-formula/grafana-formula.changes
+++ b/grafana-formula/grafana-formula.changes
@@ -1,4 +1,5 @@
   * Fix default password field description (bsc#1203698)
+  * Do not require default admin and password fields
 
 -------------------------------------------------------------------
 Fri Feb 11 13:53:07 UTC 2022 - Witek Bedyk <witold.bedyk@suse.com>

--- a/grafana-formula/grafana-formula.changes
+++ b/grafana-formula/grafana-formula.changes
@@ -1,3 +1,5 @@
+  * Fix default password field description (bsc#1203698)
+
 -------------------------------------------------------------------
 Fri Feb 11 13:53:07 UTC 2022 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/grafana-formula/metadata/form.yml
+++ b/grafana-formula/metadata/form.yml
@@ -14,7 +14,7 @@ grafana:
 
   admin_pass:
     $type: password
-    $name: Default admin password
+    $name: Initial admin password
     $required: true
     $disabled: "!formValues.grafana.enabled"
 

--- a/grafana-formula/metadata/form.yml
+++ b/grafana-formula/metadata/form.yml
@@ -4,18 +4,18 @@ grafana:
   enabled:
     $type: boolean
     $default: True
-    $help: disasbled grafana
+    $help: Enable/disable Grafana
 
   admin_user:
     $type: text
     $name: Default admin user
-    $required: true
+    $default: admin
     $disabled: "!formValues.grafana.enabled"
 
   admin_pass:
     $type: password
     $name: Initial admin password
-    $required: true
+    $default: admin
     $disabled: "!formValues.grafana.enabled"
 
   datasources:


### PR DESCRIPTION
The field `admin_password` is used to set up the initial value of the default admin password during the first run of Grafana. It cannot be used to change the password afterwards.

This change is an attempt to be more specific about the purpose of the field.

Fixes: SUSE/spacewalk#19108