### PR TITLE
Fix Uyuni/SUMA dashboard names

### DIFF
--- a/grafana-formula/grafana-formula.changes
+++ b/grafana-formula/grafana-formula.changes
@@ -1,3 +1,5 @@
+  * Fix Uyuni/SUMA dashboard names
+
 -------------------------------------------------------------------
 Mon Jan  9 11:35:25 UTC 2023 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/grafana-formula/grafana/init.sls
+++ b/grafana-formula/grafana/init.sls
@@ -6,7 +6,7 @@
 
 {%- if supported %}
 {%- if salt['pillar.get']('grafana:enabled', False) %}
-{%- if grains['is_uyuni'] %}
+{%- if salt['pillar.get']('mgr_server_is_uyuni', True) %}
   {% set product_name = 'Uyuni' %}
 {%- else %}
   {% set product_name = 'SUSE Manager' %}


### PR DESCRIPTION
The state uses pillar item `mgr_server_is_uyuni` now instead of grain item `is_uyuni` which contained wrong data.

Fixes SUSE/spacewalk#19584