### PR TITLE
Grafana formula should not be supported in a Proxy/Retail

### DIFF
--- a/grafana-formula/grafana/init.sls
+++ b/grafana-formula/grafana/init.sls
@@ -3,7 +3,7 @@
 
 # check if supported
 {%- if (grains['os_family'] == 'Suse' and grains['osrelease'] in supported_vers) %}
-  {%- if not (salt['pkg.version']('patterns-uyuni_proxy') or salt['pkg.version']('patterns-suma_proxy')) %}
+  {%- if not (salt['pkg.version']('patterns-uyuni_proxy') or salt['pkg.version']('patterns-suma_proxy') or salt['pkg.version']('patterns-suma_retail') or salt['pkg.version']('patterns-uyuni_retail')) %}
     {%- set supported = True %}
   {%- endif %}
 {%- endif %}

--- a/grafana-formula/grafana/init.sls
+++ b/grafana-formula/grafana/init.sls
@@ -5,6 +5,10 @@
 {%- if (grains['os_family'] == 'Suse' and grains['osrelease'] in supported_vers) %}
   {%- if not (salt['pkg.version']('patterns-uyuni_proxy') or salt['pkg.version']('patterns-suma_proxy') or salt['pkg.version']('patterns-suma_retail') or salt['pkg.version']('patterns-uyuni_retail')) %}
     {%- set supported = True %}
+  {%- else %}
+    os_not_supported:
+      test.fail_without_changes:
+        - name: "OS not supported!"
   {%- endif %}
 {%- endif %}
 

--- a/grafana-formula/grafana/init.sls
+++ b/grafana-formula/grafana/init.sls
@@ -2,7 +2,11 @@
 {%- set supported_vers = ['42.3', '12.3', '12.4', '12.5', '15.0', '15.1', '15.2', '15.3', '15.4', '15.5'] %}
 
 # check if supported
-{%- set supported = (grains['os_family'] == 'Suse' and grains['osrelease'] in supported_vers) %}
+{%- if (grains['os_family'] == 'Suse' and grains['osrelease'] in supported_vers) %}
+  {%- if not (salt['pkg.version']('patterns-uyuni_proxy') or salt['pkg.version']('patterns-suma_proxy')) %}
+    {%- set supported = True %}
+  {%- endif %}
+{%- endif %}
 
 {%- if supported %}
 {%- if salt['pillar.get']('grafana:enabled', False) %}


### PR DESCRIPTION
Client tools channel is not available in a Proxy/Retail using as base channel the Proxy/Retail Products.
So, we can't show the Grafana formula if we are in a SLES Operating System that has a Proxy pattern installed (as we can guess from that that we are in a SUMA/Uyuni Proxy/Retail).

**Note:** I did not open a bug report about it. Let me know if I should open one or we are fine without it @mcalmer 