### PR TITLE
Grafana HTTPS for secure web traffic

### DIFF
--- a/grafana-formula/grafana/files/grafana.ini
+++ b/grafana-formula/grafana/files/grafana.ini
@@ -28,25 +28,29 @@
 
 #################################### Server ####################################
 [server]
+{% set tls_enabled = salt['pillar.get']('grafana:tls:enabled', False) %}
+{% if tls_enabled %}
+{% set tls_config = salt['pillar.get']('grafana:tls') %}
+{% set domain = salt['grains.get']('domain') %}
+{% set fqdn = salt['grains.get']('fqdn') %}
 # Protocol (http, https, socket)
-;protocol = http
+protocol = https
 
 # The ip address to bind to, empty will bind to all interfaces
-;http_addr =
+http_addr =
 
 # The http port  to use
-;http_port = 3000
-
+http_port = {{ tls_config.port }}
 # The public facing domain name used to access grafana from a browser
-;domain = localhost
+domain = {{ domain }}
 
 # Redirect to correct domain if host header does not match domain
 # Prevents DNS rebinding attacks
-;enforce_domain = false
+enforce_domain = False
 
 # The full public facing url you use in browser, used for redirects and emails
 # If you use reverse proxy and sub path specify full url (with sub path)
-;root_url = http://localhost:3000
+root_url = https://{{ fqdn }}:{{ tls_config.port }}
 
 # Log web requests
 ;router_logging = false
@@ -58,11 +62,12 @@
 ;enable_gzip = false
 
 # https certs & key file
-;cert_file =
-;cert_key =
+cert_file = {{ tls_config.server_certificate }}
+cert_key = {{ tls_config.server_key }}
 
 # Unix socket path
 ;socket =
+{% endif %}
 
 #################################### Database ####################################
 [database]

--- a/grafana-formula/metadata/form.yml
+++ b/grafana-formula/metadata/form.yml
@@ -18,6 +18,36 @@ grafana:
     $default: admin
     $disabled: "!formValues.grafana.enabled"
 
+  tls:
+    $type: group
+    $name: TLS
+    $help: >
+      TLS configuration. Please ensure the files are present on the minion and readable for
+      the user `grafana` before applying the highstate.
+
+    enabled:
+      $type: boolean
+      $default: False
+
+    server_certificate:
+      $name: Server Certificate
+      $placeholder: /etc/grafana/grafana.crt
+      $visible: "formValues.grafana.tls.enabled"
+      $required: "formValues.grafana.tls.enabled"
+
+    server_key:
+      $name: Server Key
+      $placeholder: /etc/grafana/grafana.key
+      $visible: "formValues.grafana.tls.enabled"
+      $required: "formValues.grafana.tls.enabled"
+
+    port:
+      $type: text
+      $default: 3000
+      $name: Port
+      $help: Grafana Web UI port
+      $visible: "formValues.grafana.tls.enabled"
+
   datasources:
     $type: group
     $disabled: "!formValues.grafana.enabled"


### PR DESCRIPTION
When accessing the Grafana UI through the web, it is important to set up HTTPS to ensure the communication between Grafana and the end user is encrypted.