### PR TITLE
[prometheus] Add group filtering for SD

### DIFF
--- a/prometheus-formula/metadata/form.yml
+++ b/prometheus-formula/metadata/form.yml
@@ -81,6 +81,15 @@ prometheus:
       $visible: "this.parent.value.autodiscover_clients"
       $required: true
 
+    sd_groups:
+      $type: edit-group
+      $name: Monitored groups
+      $min_items: 0
+      $help: Limit autodiscovery to named groups. Empty list includes all clients.
+      $visible: "this.parent.value.autodiscover_clients"
+      $prototype:
+        $type: text
+
     targets_tls:
       $type: group
       $name: Targets TLS

--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,6 @@
+  * Add group filtering for service discovery relabeling
+    configuration
+
 -------------------------------------------------------------------
 Thu Nov  3 11:53:07 UTC 2022 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -56,6 +56,7 @@ scrape_configs:
 {%- endif %}
 {% set sd_username = salt['pillar.get']('prometheus:mgr:sd_username') %}
 {% set sd_password = salt['pillar.get']('prometheus:mgr:sd_password') %}
+{% set sd_groups = salt['pillar.get']('prometheus:mgr:sd_groups') %}
 {% set targets_tls = salt['pillar.get']('prometheus:mgr:targets_tls') %}
 {%- if salt['pillar.get']('prometheus:mgr:autodiscover_clients', False) and
        sd_username and sd_password %}
@@ -74,6 +75,11 @@ scrape_configs:
       key_file: {{ targets_tls.client_key }}
 {% endif %}
     relabel_configs:
+{% if sd_groups %}
+      - source_labels: [__meta_uyuni_groups]
+        regex: .*,?({{ sd_groups|join('|') }}),?.*
+        action: keep
+{% endif %}
       - source_labels: [__meta_uyuni_exporter]
         target_label: exporter
       - source_labels: [__address__]

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -176,6 +176,11 @@ scrape_configs:
       key_file: {{ tls_config.server_key }}
 {% endif %}
     relabel_configs:
+{% if sd_groups %}
+      - source_labels: [__meta_uyuni_groups]
+        regex: .*,?({{ sd_groups|join('|') }}),?.*
+        action: keep
+{% endif %}
       - source_labels: [__meta_uyuni_minion_hostname]
         target_label: hostname
       - source_labels: [__meta_uyuni_primary_fqdn]


### PR DESCRIPTION
Add a list of groups to the Prometheus formula for which service discovery targets are filtered. All matching targets are kept, remaining ones dropped.

Implements SUSE/spacewalk#23129

New form:
![image](https://github.com/SUSE/salt-formulas/assets/12249576/be0fe7c4-b8f2-4e27-b574-3c9ce5be5bc4)

Resulting service discovery targets:
![image](https://github.com/SUSE/salt-formulas/assets/12249576/e6d15d3d-1027-4dd8-b26f-d88ae5705c87)
