### PR TITLE
improve PrometheusNotIngestingSamples

### DIFF
--- a/prometheus-formula/prometheus/files/prometheus-rules.yml
+++ b/prometheus-formula/prometheus/files/prometheus-rules.yml
@@ -100,7 +100,15 @@ groups:
       description: Prometheus {{$labels.instance}} is not ingesting samples.
       summary: Prometheus is not ingesting samples.
     expr: |
-      rate(prometheus_tsdb_head_samples_appended_total{job="prometheus"}[5m]) <= 0
+      (
+        rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]) <= 0
+      and
+        (
+          sum without(scrape_job) (prometheus_target_metadata_cache_entries{%(prometheusSelector)s}) > 0
+        or
+          sum without(rule_group) (prometheus_rule_group_rules{%(prometheusSelector)s}) > 0
+        )
+      )
     for: 10m
     labels:
       severity: warning

--- a/prometheus-formula/prometheus/files/prometheus-rules.yml
+++ b/prometheus-formula/prometheus/files/prometheus-rules.yml
@@ -101,12 +101,12 @@ groups:
       summary: Prometheus is not ingesting samples.
     expr: |
       (
-        rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]) <= 0
+        rate(prometheus_tsdb_head_samples_appended_total{job="prometheus"}[5m]) <= 0
       and
         (
-          sum without(scrape_job) (prometheus_target_metadata_cache_entries{%(prometheusSelector)s}) > 0
+          sum without(scrape_job) (prometheus_target_metadata_cache_entries{job="prometheus"}) > 0
         or
-          sum without(rule_group) (prometheus_rule_group_rules{%(prometheusSelector)s}) > 0
+          sum without(rule_group) (prometheus_rule_group_rules{job="prometheus"}) > 0
         )
       )
     for: 10m


### PR DESCRIPTION
SUSE Manager shows the same behaviour as described in https://github.com/prometheus/prometheus/issues/7293, causing false alerts.

This change is a backport of https://github.com/prometheus/prometheus/pull/8054/