### PR TITLE
[prometheus] Add remote write configuration

### DIFF
--- a/prometheus-formula/metadata/form.yml
+++ b/prometheus-formula/metadata/form.yml
@@ -210,6 +210,60 @@ prometheus:
           $help: "JSON or YAML file pattern"
           $required: true
 
+  remote_write:
+    $type: group
+    $help: >
+      Integrate with remote storage systems supporting Prometheus remote write
+      protocol.
+
+    enabled:
+      $type: boolean
+      $default: False
+
+    is_receiver:
+      $name: Enable remote write receiver
+      $type: boolean
+      $default: false
+      $help: >
+        Enable API endpoint /api/v1/write accepting remote write requests.
+        Compatible systems will be able to push metrics to this instance. It is
+        recommended to use together with TLS configuration to prevent
+        unathorized data ingestion.
+
+    url:
+      $name: Remote Write URL
+      $type: text
+      $help: The URL of the remote endpoint to send samples to.
+      $match: (https?:\/\/(www.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))*
+      $visible: this.parent.value.enabled == true
+
+    tls:
+      $type: group
+      $name: Remote Storage TLS
+      $visible: this.parent.value.enabled == true
+      $help: >
+        TLS configuration for remote write API. Please ensure the files are present before
+        applying the highstate.
+
+      enabled:
+        $type: boolean
+        $default: False
+
+      ca_certificate:
+        $name: CA Certificate
+        $default: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+        $visible: this.parent.value.enabled == true
+
+      remote_certificate:
+        $name: Client Certificate
+        $placeholder: /etc/ssl/server.crt
+        $visible: this.parent.value.enabled == true
+
+      remote_key:
+        $name: Client Private Key
+        $placeholder: /etc/ssl/server.key
+        $visible: this.parent.value.enabled == true
+
   blackbox_exporter:
     $type: group
     $help: Prometheus exporter for blackbox probing of endpoints.

--- a/prometheus-formula/prometheus-formula.changes
+++ b/prometheus-formula/prometheus-formula.changes
@@ -1,3 +1,4 @@
+  * Add remote write configuration
   * Add group filtering for service discovery relabeling
     configuration
 

--- a/prometheus-formula/prometheus/files/prometheus-service.conf
+++ b/prometheus-formula/prometheus/files/prometheus-service.conf
@@ -1,3 +1,3 @@
 [Service]
 EnvironmentFile=
-Environment="ARGS={{ args }}"
+Environment="ARGS={{ args }}{{ enable_receiver }}"

--- a/prometheus-formula/prometheus/files/prometheus.yml
+++ b/prometheus-formula/prometheus/files/prometheus.yml
@@ -198,3 +198,15 @@ scrape_configs:
       - target_label: exporter
         replacement: ''
 {% endif %}
+
+{% set remote_write = salt['pillar.get']('prometheus:remote_write') %}
+{% if remote_write.enabled %}
+remote_write:
+  - url: {{ remote_write.url }}
+{% if remote_write.tls.enabled %}
+    tls_config:
+      ca_file: {{ remote_write.tls.ca_certificate }}
+      cert_file: {{  remote_write.tls.remote_certificate}}
+      key_file: {{ remote_write.tls.remote_key }}
+{% endif %}
+{% endif %}

--- a/prometheus-formula/prometheus/init.sls
+++ b/prometheus-formula/prometheus/init.sls
@@ -8,6 +8,7 @@
 {%- set default_rules = salt['pillar.get']('prometheus:alerting:default_rules', False) %}
 {%- set uyuni_server_hostname = salt['pillar.get']('mgr_origin_server', grains['master'])%}
 {%- set tls_enabled = salt['pillar.get']('prometheus:tls:enabled', False) %}
+{%- set remote_write_receiver_enabled = salt['pillar.get']('prometheus:remote_write:is_receiver', False) %}
 {%  set prometheus_web_config_file = '/etc/prometheus/web.yml' %}
 {%  set blackbox_exporter_web_config_file = '/etc/prometheus/exporters/blackbox-web.yml' %}
 
@@ -111,9 +112,13 @@ prometheus_running:
     - mode: 644
     - defaults:
         args: ''
-{% if tls_enabled %}
+        enable_receiver: ''
     - context:
+{% if tls_enabled %}
         args: {{ ' --web.config.file=' ~ prometheus_web_config_file }}
+{% endif %}
+{% if remote_write_receiver_enabled %}
+        enable_receiver: {{ ' --web.enable-remote-write-receiver' }}
 {% endif %}
   service.running:
     - name: {{ prometheus.prometheus_service }}


### PR DESCRIPTION
The change adds support for configuring Prometheus remote write protocol configuration for pushing samples to a compatible external storage system.  
It also allows to run Prometheus with remote write receiver enabled for the instance accepting metrics from another Prometheus server.

Implements SUSE/spacewalk#23360

New UI:
![image](https://github.com/SUSE/salt-formulas/assets/12249576/977bd22e-d7be-4481-b7f6-997d236c58dd)
