### PR TITLE
[liberate] Reverted the re-installation flag to be enabled by default

### DIFF
--- a/liberate-formula/README.md
+++ b/liberate-formula/README.md
@@ -62,8 +62,8 @@ The Liberate Formula is available as an RPM (See 'Install formula' steps above).
      - Select the `Liberate` and click on the `Save` button. 
        - A new tab called `Liberate` will apear.
        - You can switch to the `Liberate` tab and find the `Reinstall all packages after conversion` option
-         - Please select this option if you want to reinstall all the packages during conversion to ensure they have SUSE signatures and you do not keep any previous package. If you do so, remember to click on the `Save Formula` button.
-         - If you prefer to not alter the state of your system during the migration leave this box deselected. You will beable to perform the reinstallation afterwards.
+         - Please keep this option selected if you want to reinstall all the packages during conversion, to ensure they have SUSE signatures and you do not keep any previous package.
+         - If you prefer to not alter the state of your system during the migration, please uncheck this box. If you do so, remember to click on the `Save Formula` button. You will be able to perform the reinstallation afterwards.
 
 We have now a System Group that has assigned the `Liberate` formula. This formula will only apply once to convert the system to SUSE Liberty Linux, even if you run it multiple times. Now it's time to assign it to the Activation Key
 

--- a/liberate-formula/liberate-formula.changes
+++ b/liberate-formula/liberate-formula.changes
@@ -1,10 +1,9 @@
 -------------------------------------------------------------------
-Thu Dec 20 11:00:00 UTC 2023 - Thomas Florio <thomas.florio@suse.com>
+Mon Jan 15 11:00:00 UTC 2023 - Thomas Florio <thomas.florio@suse.com>
 
 - Integrate into salt-formulas project
 - Make sure the formula is idempotent and do not alter the system
   after the migration
-- Changed default behaviour to not reinstall all packages
 
 -------------------------------------------------------------------
 Thu Nov  9 16:46:44 UTC 2023 - Ricardo Mateus <rmateus@suse.com>

--- a/liberate-formula/metadata/form.yml
+++ b/liberate-formula/metadata/form.yml
@@ -5,4 +5,4 @@ liberate:
      $name: 'Reinstall all packages after conversion'
      $type: boolean
      $help: 'If you want all the packages in your SLL system to have signatures from SUSE, please enable this option'
-     $default: false
+     $default: true


### PR DESCRIPTION
This PR changes the default value of the reinstallation flag for the liberate formula, so that all the packages are reinstalled by default.