### PR TITLE
[liberate] Update Activation Key instructions

### DIFF
--- a/liberate-formula/README.md
+++ b/liberate-formula/README.md
@@ -43,7 +43,7 @@ Now it's time to start basic configuration to have all the software channels for
         - EL8: `RHEL8-Pool for x86_64`
         - EL9: `EL9-Pool for x86_64`
     - `Child Channel`
-      - Use `include recommended` where available or select all if unavailable
+      - select all available channels
     - `Add-On system type`: Leave all blank
     - `Contact Method`: Default
     - `Universal Default`: Leave unchecked


### PR DESCRIPTION
When using the `RHEL8-Pool for x86_64` and `EL9-Pool for x86_64` Base channels for an activation key, the Child Channels menu does not show as recommended the ones which are needed to successfully migrate to SLL.

For the purpose of using Liberate formula, we should probably suggest to add all available child channels or provide a list of which ones to include.

![Screenshot from 2024-02-13 10-26-44](https://github.com/SUSE/salt-formulas/assets/61153476/300eb530-72bd-40a9-899e-6d142453745b)
![Screenshot from 2024-02-12 17-29-35](https://github.com/SUSE/salt-formulas/assets/61153476/458020d8-496f-4ba7-88bb-f715a027397e)
