### PR TITLE
Fix `--web.config.file` flag name for web configuration file for TLS support

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,3 +1,5 @@
+
+  * Fix flag name for web config file for TLS support (bsc#1226035)
   * Fix PostgreSQL exporter drop-in directory name on Debian
     (bsc#1226605)
 

--- a/prometheus-exporters-formula/prometheus-exporters/init.sls
+++ b/prometheus-exporters-formula/prometheus-exporters/init.sls
@@ -74,7 +74,15 @@ node_exporter:
     {% set node_exporter_args = node_exporter_args ~ ' --web.listen-address=' ~ node_exporter_address %}
   {% endif %}
   {% if tls_enabled %}
-    {% set node_exporter_args = node_exporter_args ~ ' --web.config=' ~ web_config_file %}
+    {% set node_exporter_version = salt['pkg.version'](exporters.node_exporter_package) %}
+    {% if not node_exporter_version %}
+      {% set node_exporter_version = salt['pkg.latest_version'](exporters.node_exporter_package) %}
+    {% endif %}
+    {% if salt['pkg.version_cmp'](node_exporter_version, '1.5.0') >= 0 %}
+        {% set node_exporter_args = node_exporter_args ~ ' --web.config.file=' ~ web_config_file %}
+    {% else %}
+        {% set node_exporter_args = node_exporter_args ~ ' --web.config=' ~ web_config_file %}
+    {% endif %}
   {% endif %}
   pkg.installed:
     - name: {{ exporters.node_exporter_package }}


### PR DESCRIPTION
As described in the title.
In the context of https://bugzilla.suse.com/show_bug.cgi?id=1226035