### PR TITLE
Fix PostgreSQL exporter service name on Debian

### DIFF
--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,4 +1,4 @@
-  * Fix PostgeSQL exporter drop-in directory name on Debian
+  * Fix PostgreSQL exporter drop-in directory name on Debian
     (bsc#1226605)
 
 -------------------------------------------------------------------

--- a/prometheus-exporters-formula/prometheus-exporters-formula.changes
+++ b/prometheus-exporters-formula/prometheus-exporters-formula.changes
@@ -1,3 +1,6 @@
+  * Fix PostgeSQL exporter drop-in directory name on Debian
+    (bsc#1226605)
+
 -------------------------------------------------------------------
 Thu May 16 15:01:10 UTC 2024 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/prometheus-exporters-formula/prometheus-exporters/map.jinja
+++ b/prometheus-exporters-formula/prometheus-exporters/map.jinja
@@ -23,7 +23,7 @@
         'apache_exporter_service_config': '/etc/default/prometheus-apache-exporter',
         'postgres_exporter_package': 'prometheus-postgres-exporter',
         'postgres_exporter_service': 'prometheus-postgres-exporter',
-        'postgres_exporter_service_config': '/etc/systemd/system/prometheus-postgres_exporter.service.d/60-suse-salt-formula.conf',
+        'postgres_exporter_service_config': '/etc/systemd/system/prometheus-postgres-exporter.service.d/60-suse-salt-formula.conf',
         'postgres_exporter_password_file': '/etc/postgres_exporter/pg_passwd',
         'exporter_exporter_package': 'prometheus-exporter-exporter',
         'exporter_exporter_service': 'prometheus-exporter-exporter',


### PR DESCRIPTION
Fix the typo in the Debian service name for PostgreSQL exporter

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1226605