### PR TITLE
Add MAC based terminal naming option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ VIRTUALIZATION_VERSION=0.6.2
 SYSTEM_LOCK_VERSION=0.1
 UYUNI_CONFIG_VERSION=0.2
 LIBERATE_VERSION=0.1.0
+PXE_VERSION=0.2.0
 
 locale:: clean
 	git archive --format=tar.gz --prefix=locale-formula-${LOCALE_VERSION}/ HEAD:locale-formula/ >locale-formula-${LOCALE_VERSION}.tar.gz
@@ -35,6 +36,9 @@ uyuni-config:: clean
 
 liberate:: clean
 	git archive --format=tar.gz --prefix=liberate-formula-${LIBERATE_VERSION}/ HEAD:liberate-formula/ >liberate-formula-${LIBERATE_VERSION}.tar.gz
+
+pxe:: clean
+	git archive --format=tar.gz --prefix=pxe-formula-${PXE_VERSION}/ HEAD:pxe-formula/ >pxe-formula-${PXE_VERSION}.tar.gz
 
 clean::
 	find . -name "*~" | xargs rm -f

--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,12 +1,9 @@
 -------------------------------------------------------------------
 Wed Sep  4 11:57:34 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
-- Add MAC based terminal naming option (jsc#SUMA-314)
-
--------------------------------------------------------------------
-Thu Apr 27 13:52:24 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
-
-- Store pxe configuration in grains
+- Update to version 0.2.0
+  * Add MAC based terminal naming option (jsc#SUMA-314)
+  * Store pxe configuration in grains
 
 -------------------------------------------------------------------
 Wed Feb 10 11:46:07 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>

--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Sep  4 11:57:34 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
+
+- Add MAC based terminal naming option (jsc#SUMA-314)
+
+-------------------------------------------------------------------
 Thu Apr 27 13:52:24 UTC 2023 - Vladimir Nadvornik <nadvornik@suse.cz>
 
 - Store pxe configuration in grains

--- a/pxe-formula/pxe-formula.spec
+++ b/pxe-formula/pxe-formula.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           pxe-formula
-Version:        0.1
+Version:        0.2.0
 Release:        0
 Summary:        Formula for atftpd server on POS branchserver
 License:        GPL-2.0

--- a/pxe-formula/pxe/files/pxecfg.grub2.template
+++ b/pxe-formula/pxe/files/pxecfg.grub2.template
@@ -23,6 +23,8 @@
 {%-   set naming_config = naming_config + " USE_FQDN_MINION_ID=1"  %}
 {%- elif minion_id_naming == 'HWType' %}
 {%-   set naming_config = naming_config + " DISABLE_HOSTNAME_ID=1" %}
+{%- elif minion_id_naming == 'MAC' %}
+{%-   set naming_config = naming_config + " USE_MAC_MINION_ID=1"   %}
 {%- endif %}
 
 default=0

--- a/pxe-formula/pxe/files/pxecfg.template
+++ b/pxe-formula/pxe/files/pxecfg.template
@@ -23,6 +23,8 @@
 {%-   set naming_config = naming_config + " USE_FQDN_MINION_ID=1"  %}
 {%- elif minion_id_naming == 'HWType' %}
 {%-   set naming_config = naming_config + " DISABLE_HOSTNAME_ID=1" %}
+{%- elif minion_id_naming == 'MAC' %}
+{%-   set naming_config = naming_config + " USE_MAC_MINION_ID=1"   %}
 {%- endif %}
 
 DEFAULT netboot


### PR DESCRIPTION
PXE formula part for https://github.com/SUSE/spacewalk/issues/24801

Standardizing PXE formula releasing as the other formulas and bumping version number to 0.2.0

Change in changes files seems wrong, but the formula with that change was never released and build team complained before when we had duplicated entries.

Issue: https://github.com/SUSE/spacewalk/issues/24801