### PR TITLE
Fix license versions for tftp and pxe formulas

### DIFF
--- a/pxe-formula/pxe-formula.changes
+++ b/pxe-formula/pxe-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 14 10:38:56 UTC 2025 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix license snippets in source to be correctly GPL-2.0+
+
+-------------------------------------------------------------------
 Wed Sep  4 11:57:34 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Update to version 0.2.0

--- a/pxe-formula/pxe-formula.spec
+++ b/pxe-formula/pxe-formula.spec
@@ -21,7 +21,7 @@ Name:           pxe-formula
 Version:        0.2.0
 Release:        0
 Summary:        Formula for atftpd server on POS branchserver
-License:        GPL-2.0-only
+License:        GPL-2.0-or-later
 Group:          System/Packages
 URL:            https://github.com/SUSE/salt-formulas
 Source:         pxe-formula-%{version}.tar.xz

--- a/pxe-formula/pxe-formula.spec
+++ b/pxe-formula/pxe-formula.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package pxe-formula
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,16 +15,17 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
+%define fname pxe
 Name:           pxe-formula
 Version:        0.2.0
 Release:        0
 Summary:        Formula for atftpd server on POS branchserver
-License:        GPL-2.0
+License:        GPL-2.0-only
 Group:          System/Packages
+URL:            https://github.com/SUSE/salt-formulas
 Source:         pxe-formula-%{version}.tar.xz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-%define fname pxe
 
 %description
 Formula for install, setup and uninstall of syslinux pxe boot on POS branchserver
@@ -35,15 +36,14 @@ Formula for install, setup and uninstall of syslinux pxe boot on POS branchserve
 %build
 
 %install
-mkdir -p %{buildroot}/usr/share/susemanager/formulas/states/%{fname}/files
-mkdir -p %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
-cp -R %{fname}/* %{buildroot}/usr/share/susemanager/formulas/states/%{fname}
-cp form.yml %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
-cp metadata.yml %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
+mkdir -p %{buildroot}%{_datadir}/susemanager/formulas/states/%{fname}/files
+mkdir -p %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
+cp -R %{fname}/* %{buildroot}%{_datadir}/susemanager/formulas/states/%{fname}
+cp form.yml %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
+cp metadata.yml %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
 
 
 %files
-%defattr(-,root,root,-)
-/usr/share/susemanager
+%{_datadir}/susemanager
 
 %changelog

--- a/pxe-formula/pxe/init.sls
+++ b/pxe-formula/pxe/init.sls
@@ -2,7 +2,7 @@
 #
 # pxe-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # pxe-formula is distributed in the hope that it will be useful,

--- a/pxe-formula/pxe/map.jinja
+++ b/pxe-formula/pxe/map.jinja
@@ -2,7 +2,7 @@
 #
 # pxe-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # pxe-formula is distributed in the hope that it will be useful,

--- a/pxe-formula/pxe/uninstall.sls
+++ b/pxe-formula/pxe/uninstall.sls
@@ -2,7 +2,7 @@
 #
 # pxe-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # pxe-formula is distributed in the hope that it will be useful,

--- a/tftpd-formula/tftpd-formula.changes
+++ b/tftpd-formula/tftpd-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 14 10:40:01 UTC 2025 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix license snippets in source to be correctly GPL-2.0+
+
+-------------------------------------------------------------------
 Wed Dec  2 17:04:29 UTC 2020 - Ondrej Holecek <oholecek@suse.com>
 
 - Add IP or empty string match for network address field

--- a/tftpd-formula/tftpd-formula.spec
+++ b/tftpd-formula/tftpd-formula.spec
@@ -21,7 +21,7 @@ Name:           tftpd-formula
 Version:        0.1
 Release:        0
 Summary:        Formula for tftpd server on POS branchserver
-License:        GPL-2.0-only
+License:        GPL-2.0-or-later
 Group:          System/Packages
 URL:            https://github.com/SUSE/salt-formulas
 Source:         tftpd-formula-%{version}.tar.xz

--- a/tftpd-formula/tftpd-formula.spec
+++ b/tftpd-formula/tftpd-formula.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package tftpd-formula
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,16 +15,17 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
+%define fname tftpd
 Name:           tftpd-formula
 Version:        0.1
 Release:        0
 Summary:        Formula for tftpd server on POS branchserver
-License:        GPL-2.0
+License:        GPL-2.0-only
 Group:          System/Packages
+URL:            https://github.com/SUSE/salt-formulas
 Source:         tftpd-formula-%{version}.tar.xz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-%define fname tftpd
 
 %description
 Formula for install, setup and uninstall of tftpd server on POS branchserver
@@ -35,15 +36,14 @@ Formula for install, setup and uninstall of tftpd server on POS branchserver
 %build
 
 %install
-mkdir -p %{buildroot}/usr/share/susemanager/formulas/states/%{fname}/files
-mkdir -p %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
-cp -R %{fname}/* %{buildroot}/usr/share/susemanager/formulas/states/%{fname}
-cp form.yml %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
-cp metadata.yml %{buildroot}/usr/share/susemanager/formulas/metadata/%{fname}
+mkdir -p %{buildroot}%{_datadir}/susemanager/formulas/states/%{fname}/files
+mkdir -p %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
+cp -R %{fname}/* %{buildroot}%{_datadir}/susemanager/formulas/states/%{fname}
+cp form.yml %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
+cp metadata.yml %{buildroot}%{_datadir}/susemanager/formulas/metadata/%{fname}
 
 
 %files
-%defattr(-,root,root,-)
-/usr/share/susemanager
+%{_datadir}/susemanager
 
 %changelog

--- a/tftpd-formula/tftpd/init.sls
+++ b/tftpd-formula/tftpd/init.sls
@@ -2,7 +2,7 @@
 #
 # tftpd-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # tftpd-formula is distributed in the hope that it will be useful,

--- a/tftpd-formula/tftpd/map.jinja
+++ b/tftpd-formula/tftpd/map.jinja
@@ -2,7 +2,7 @@
 #
 # tftpd-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # tftpd-formula is distributed in the hope that it will be useful,

--- a/tftpd-formula/tftpd/uninstall.sls
+++ b/tftpd-formula/tftpd/uninstall.sls
@@ -2,7 +2,7 @@
 #
 # tftpd-formula is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # tftpd-formula is distributed in the hope that it will be useful,


### PR DESCRIPTION
- license is GPL-2.0
- spec-clean tftp and pxe formula spec files