### PR TITLE
Do not reinstall all packages per default

### DIFF
--- a/liberate-formula/liberate-formula.changes
+++ b/liberate-formula/liberate-formula.changes
@@ -1,3 +1,5 @@
+* Change reinstall parameter default value to false
+
 -------------------------------------------------------------------
 Mon Jan 15 11:00:00 UTC 2024 - Thomas Florio <thomas.florio@suse.com>
 

--- a/liberate-formula/liberate/init.sls
+++ b/liberate-formula/liberate/init.sls
@@ -5,7 +5,7 @@
 
 {% set release = grains.get('osmajorrelease', None)|int() %}
 {% set osName = grains.get('os', None) %}
-{% set reinstallPackages = salt['pillar.get']('liberate:reinstall_packages', true) %}
+{% set reinstallPackages = salt['pillar.get']('liberate:reinstall_packages', false) %}
 
 {% set liberated = false %}
 {% set liberationDate = salt['system.get_system_date']() %}

--- a/liberate-formula/metadata/form.yml
+++ b/liberate-formula/metadata/form.yml
@@ -5,4 +5,4 @@ liberate:
      $name: 'Reinstall all packages after conversion'
      $type: boolean
      $help: 'If you want all the packages in your SLL system to have signatures from SUSE, please enable this option'
-     $default: true
+     $default: false


### PR DESCRIPTION
Change the default value to `false` in order to not have all packages reinstalled after conversion, i.e. a liberation would only change the channel subscriptions.