### PR TITLE
Liberate formula support for EL10

### DIFF
--- a/liberate-formula/liberate-formula.changes
+++ b/liberate-formula/liberate-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 15 12:00:00 UTC 2026 - Oscar Barrios <obarrios@suse.com>
+
+- Liberate formula support for EL10
+
+-------------------------------------------------------------------
 Thu Dec 11 13:20:46 UTC 2025 - Thomas Florio <thomas.florio@suse.com>
 
 - Version 0.1.2

--- a/liberate-formula/liberate/init.sls
+++ b/liberate-formula/liberate/init.sls
@@ -14,8 +14,70 @@
 {% set isLiberty = salt['file.search']('/etc/os-release', 'SUSE Liberty Linux') %}
 {% set isSleES = salt['file.search']('/etc/os-release', 'SLES Expanded Support') %}
 
+# EL 10
+{% if release == 10 %}
+{% if not isLiberty %}
+
+/usr/share/redhat-release:
+  file.absent
+
+/etc/dnf/protected.d/redhat-release.conf:
+  file.absent
+
+{% if osName == 'Rocky' %}
+/usr/share/rocky-release/:
+  file.absent
+
+remove_release_package:
+  cmd.run:
+    - name: "rpm -e --nodeps rocky-release"
+{% endif %}
+
+{% if osName == 'AlmaLinux' %}
+/usr/share/almalinux-release/:
+  file.absent
+
+remove_release_package:
+  cmd.run:
+    - name: "rpm -e --nodeps almalinux-release"
+{% endif %}
+
+{% if osName == 'OEL' %}
+/usr/share/oraclelinux-release/:
+  file.absent
+
+remove_release_package:
+  cmd.run:
+    - name: "rpm -e --nodeps oraclelinux-release"
+{% endif %}
+
+install_package_10:
+  pkg.installed:
+    - name: sll-release
+    - refresh: True
+
+{% if installLogos %}
+install_logos_10:
+  pkg.installed:
+    - name: sll-logos
+    - refresh: True
+{% endif %}
+
+{% if reinstallPackages %}
+re_install_from_SLL:
+  cmd.run:
+    - name: "dnf -x 'venv-salt-minion' reinstall '*' -y >> /var/log/dnf_sll_migration.log"
+    - require:
+      - pkg: install_package_10
+{% endif %}
+
+{% set liberated = true %}
+
+{% endif %} # end if for search
+
+
 # EL 9
-{% if release == 9 %}
+{% elif release == 9 %}
 {% if not isLiberty %}
 
 /usr/share/redhat-release:

--- a/liberate-formula/liberate/init.sls
+++ b/liberate-formula/liberate/init.sls
@@ -24,6 +24,12 @@
 /etc/dnf/protected.d/redhat-release.conf:
   file.absent
 
+{% if osName == 'RedHat' or osName == 'CentOS' %}
+remove_release_package:
+  cmd.run:
+    - name: "rpm -e --nodeps redhat-release"
+{% endif %}
+
 {% if osName == 'Rocky' %}
 /usr/share/rocky-release/:
   file.absent
@@ -55,6 +61,8 @@ install_package_10:
   pkg.installed:
     - name: sll-release
     - refresh: True
+    - require:
+      - cmd: remove_release_package
 
 {% if installLogos %}
 install_logos_10:

--- a/liberate-formula/liberate/init.sls
+++ b/liberate-formula/liberate/init.sls
@@ -18,51 +18,10 @@
 {% if release == 10 %}
 {% if not isLiberty %}
 
-/usr/share/redhat-release:
-  file.absent
-
-/etc/dnf/protected.d/redhat-release.conf:
-  file.absent
-
-{% if osName == 'RedHat' or osName == 'CentOS' %}
-remove_release_package:
-  cmd.run:
-    - name: "rpm -e --nodeps redhat-release"
-{% endif %}
-
-{% if osName == 'Rocky' %}
-/usr/share/rocky-release/:
-  file.absent
-
-remove_release_package:
-  cmd.run:
-    - name: "rpm -e --nodeps rocky-release"
-{% endif %}
-
-{% if osName == 'AlmaLinux' %}
-/usr/share/almalinux-release/:
-  file.absent
-
-remove_release_package:
-  cmd.run:
-    - name: "rpm -e --nodeps almalinux-release"
-{% endif %}
-
-{% if osName == 'OEL' %}
-/usr/share/oraclelinux-release/:
-  file.absent
-
-remove_release_package:
-  cmd.run:
-    - name: "rpm -e --nodeps oraclelinux-release"
-{% endif %}
-
 install_package_10:
   pkg.installed:
     - name: sll-release
     - refresh: True
-    - require:
-      - cmd: remove_release_package
 
 {% if installLogos %}
 install_logos_10:


### PR DESCRIPTION
This pull request updates the SaltStack state file to extend support for a new OS release. The main change is to ensure that the configuration logic applies to both EL 9 and the newly added EL 10 releases.

**Expanded OS release support:**

* Updated the conditional in `liberate/init.sls` to apply the configuration for both EL 9 and EL 10 by checking if `release` is in `[9, 10]` instead of only `9`.

**Ricardo:**
For Liberty 10 the specifications have changed.
SLL-Release will not remove the redhat-release
anymore, meaning that we don't need to remove the
lock files.

This simplifies the migration process, and we should
only need to install SLL-Release package and it take
care of all the needed changes to the system.

More information at https://bugzilla.suse.com/show_bug.cgi?id=1265975
