### PR TITLE
Include bind-forwarders.conf if include_forwarders option is enabled

### DIFF
--- a/bind-formula/bind-formula.changes
+++ b/bind-formula/bind-formula.changes
@@ -1,3 +1,6 @@
+- Include bind-forwarders.conf if include-forwarders option
+  is enabled (bsc#1265217)
+
 -------------------------------------------------------------------
 Tue Jan  6 13:35:20 UTC 2026 - Ondrej Holecek <oholecek@suse.com>
 

--- a/bind-formula/bind/files/bind-container.service.jinja
+++ b/bind-formula/bind/files/bind-container.service.jinja
@@ -16,6 +16,9 @@ ExecStart=/bin/sh -c '/usr/bin/podman run \
         -p 53:53/udp -p 53:53/tcp \
         -v /etc/named.d:/etc/named.d:ro,Z \
         -v /etc/named.conf:/etc/named.conf:ro,Z \
+        {%- if salt["pillar.get"]("bind:config:include_forwarders", False) %}
+        -v /run/netconfig/bind-forwarders.conf:/run/netconfig/bind-forwarders.conf:ro,Z \
+        {%- endif %}
         -v {{ map.named_directory }}:{{ map.container_named_directory }}:Z \
         -v {{ key_directory }}:{{ key_directory }}:ro,Z \
 	--conmon-pidfile %t/bind-container.pid \


### PR DESCRIPTION
Include `/run/netconfig/bind-forwarders.conf` volume if include_forwarders option is enabled.

Issue: https://github.com/SUSE/spacewalk/issues/30713